### PR TITLE
Improved data types and memory usage

### DIFF
--- a/video/agon_audio.h
+++ b/video/agon_audio.h
@@ -12,7 +12,6 @@
 
 #include <memory>
 #include <unordered_map>
-#include <array>
 #include <fabgl.h>
 
 #include "envelopes/volume.h"
@@ -60,7 +59,7 @@ struct audio_sample {
 	std::unordered_map<uint8_t, std::weak_ptr<audio_channel>> channels;	// Channels playing this sample
 };
 
-extern std::array<std::shared_ptr<audio_sample>, MAX_AUDIO_SAMPLES> samples;
+extern std::unordered_map<uint8_t, std::shared_ptr<audio_sample>> samples;	// Storage for the sample data
 
 audio_sample::~audio_sample() {
 	// iterate over channels
@@ -222,9 +221,9 @@ void audio_channel::setWaveform(int8_t waveformType, std::shared_ptr<audio_chann
 					if (sample) {
 						newWaveform = new EnhancedSamplesGenerator(sample);
 						// remove this channel from other samples
-						for (auto sample : samples) {
-							if (sample) {
-								sample->channels.erase(_channel);
+						for (auto samplePair : samples) {
+							if (samplePair.second) {
+								samplePair.second->channels.erase(_channel);
 							}
 						}
 						sample->channels[_channel] = channelRef;

--- a/video/agon_audio.h
+++ b/video/agon_audio.h
@@ -18,46 +18,46 @@
 #include "envelopes/volume.h"
 #include "envelopes/frequency.h"
 
-extern void audioTaskAbortDelay(int channel);
+extern void audioTaskAbortDelay(uint8_t channel);
 
 // The audio channel class
 //
 class audio_channel {	
 	public:
-		audio_channel(int channel);
+		audio_channel(uint8_t channel);
 		~audio_channel();
-		word	play_note(byte volume, word frequency, word duration);
-		byte	getStatus();
-		void	setWaveform(int8_t waveformType, std::shared_ptr<audio_channel> channelRef);
-		void	setVolume(byte volume);
-		void	setFrequency(word frequency);
-		void	setVolumeEnvelope(std::shared_ptr<VolumeEnvelope> envelope);
-		void	setFrequencyEnvelope(std::shared_ptr<FrequencyEnvelope> envelope);
-		void	loop();
-		byte	channel() { return _channel; }
+		uint8_t		play_note(uint8_t volume, uint16_t frequency, int32_t duration);
+		uint8_t		getStatus();
+		void		setWaveform(int8_t waveformType, std::shared_ptr<audio_channel> channelRef);
+		void		setVolume(uint8_t volume);
+		void		setFrequency(uint16_t frequency);
+		void		setVolumeEnvelope(std::shared_ptr<VolumeEnvelope> envelope);
+		void		setFrequencyEnvelope(std::shared_ptr<FrequencyEnvelope> envelope);
+		void		loop();
+		uint8_t		channel() { return _channel; }
 	private:
-		void	waitForAbort();
-		byte	getVolume(word elapsed);
-		word	getFrequency(word elapsed);
-		bool	isReleasing(word elapsed);
-		bool	isFinished(word elapsed);
-		std::unique_ptr<WaveformGenerator> _waveform;
-		byte _waveformType;
-		byte _state;
-		byte _channel;
-		byte _volume;
-		word _frequency;
-		long _duration;
-		long _startTime;
-		std::shared_ptr<VolumeEnvelope> _volumeEnvelope;
-		std::shared_ptr<FrequencyEnvelope> _frequencyEnvelope;
+		void		waitForAbort();
+		uint8_t		getVolume(uint32_t elapsed);
+		uint16_t	getFrequency(uint32_t elapsed);
+		bool		isReleasing(uint32_t elapsed);
+		bool		isFinished(uint32_t elapsed);
+		uint8_t		_state;
+		uint8_t		_channel;
+		uint8_t		_volume;
+		uint16_t	_frequency;
+		int32_t		_duration;
+		uint32_t	_startTime;
+		uint8_t		_waveformType;
+		std::unique_ptr<WaveformGenerator>	_waveform;
+		std::shared_ptr<VolumeEnvelope>		_volumeEnvelope;
+		std::shared_ptr<FrequencyEnvelope>	_frequencyEnvelope;
 };
 
 struct audio_sample {
 	~audio_sample();
-	int length = 0;					// Length of the sample in bytes
-	int8_t * data = nullptr;		// Pointer to the sample data
-	std::unordered_map<byte, std::weak_ptr<audio_channel>> channels;	// Channels playing this sample
+	uint32_t		length = 0;			// Length of the sample in bytes
+	int8_t *		data = nullptr;		// Pointer to the sample data
+	std::unordered_map<uint8_t, std::weak_ptr<audio_channel>> channels;	// Channels playing this sample
 };
 
 extern std::array<std::shared_ptr<audio_sample>, MAX_AUDIO_SAMPLES> samples;
@@ -114,7 +114,7 @@ int EnhancedSamplesGenerator::getSample() {
 	}
 
 	auto samplePtr = _sample.lock();
-	int sample = samplePtr->data[_index++];
+	auto sample = samplePtr->data[_index++];
 	
 	// Insert looping magic here
 	if (_index >= samplePtr->length) {
@@ -130,7 +130,7 @@ int EnhancedSamplesGenerator::getSample() {
 	return sample;
 }
 
-audio_channel::audio_channel(int channel) {
+audio_channel::audio_channel(uint8_t channel) {
 	this->_channel = channel;
 	this->_state = AUDIO_STATE_IDLE;
 	this->_volume = 0;
@@ -150,7 +150,7 @@ audio_channel::~audio_channel() {
 	debug_log("audio_driver: deinit %d\n\r", this->_channel);
 }
 
-word audio_channel::play_note(byte volume, word frequency, word duration) {
+uint8_t audio_channel::play_note(uint8_t volume, uint16_t frequency, int32_t duration) {
 	switch (this->_state) {
 		case AUDIO_STATE_IDLE:
 		case AUDIO_STATE_RELEASE:
@@ -164,8 +164,8 @@ word audio_channel::play_note(byte volume, word frequency, word duration) {
 	return 0;
 }
 
-byte audio_channel::getStatus() {
-	byte status = 0;
+uint8_t audio_channel::getStatus() {
+	uint8_t status = 0;
 	if (this->_waveform && this->_waveform->enabled()) {
 		status |= AUDIO_STATUS_ACTIVE;
 		if (this->_duration == -1) {
@@ -259,7 +259,7 @@ void audio_channel::setWaveform(int8_t waveformType, std::shared_ptr<audio_chann
 	}
 }
 
-void audio_channel::setVolume(byte volume) {
+void audio_channel::setVolume(uint8_t volume) {
 	debug_log("audio_driver: setVolume %d\n\r", volume);
 
 	if (this->_waveform) {
@@ -306,7 +306,7 @@ void audio_channel::setVolume(byte volume) {
 	}
 }
 
-void audio_channel::setFrequency(word frequency) {
+void audio_channel::setFrequency(uint16_t frequency) {
 	debug_log("audio_driver: setFrequency %d\n\r", frequency);
 	this->_frequency = frequency;
 
@@ -349,21 +349,21 @@ void audio_channel::waitForAbort() {
 	}
 }
 
-byte audio_channel::getVolume(word elapsed) {
+uint8_t audio_channel::getVolume(uint32_t elapsed) {
 	if (this->_volumeEnvelope) {
 		return this->_volumeEnvelope->getVolume(this->_volume, elapsed, this->_duration);
 	}
 	return this->_volume;
 }
 
-word audio_channel::getFrequency(word elapsed) {
+uint16_t audio_channel::getFrequency(uint32_t elapsed) {
 	if (this->_frequencyEnvelope) {
-		return this->_frequencyEnvelope->getFrequency((uint16_t) this->_frequency, (uint16_t) elapsed, this->_duration);
+		return this->_frequencyEnvelope->getFrequency(this->_frequency, elapsed, this->_duration);
 	}
 	return this->_frequency;
 }
 
-bool audio_channel::isReleasing(word elapsed) {
+bool audio_channel::isReleasing(uint32_t elapsed) {
 	if (this->_volumeEnvelope) {
 		return this->_volumeEnvelope->isReleasing(elapsed, this->_duration);
 	}
@@ -373,7 +373,7 @@ bool audio_channel::isReleasing(word elapsed) {
 	return elapsed >= this->_duration;
 }
 
-bool audio_channel::isFinished(word elapsed) {
+bool audio_channel::isFinished(uint32_t elapsed) {
 	if (this->_volumeEnvelope) {
 		return this->_volumeEnvelope->isFinished(elapsed, this->_duration);
 	}
@@ -410,7 +410,7 @@ void audio_channel::loop() {
 		case AUDIO_STATE_PLAYING:
 			if (this->_duration >= 0) {
 				// simple playback - delay until we have reached our duration
-				word elapsed = millis() - this->_startTime;
+				uint32_t elapsed = millis() - this->_startTime;
 				debug_log("audio_driver: elapsed %d\n\r", elapsed);
 				if (elapsed >= this->_duration) {
 					this->_waveform->enable(false);
@@ -428,7 +428,7 @@ void audio_channel::loop() {
 			break;
 		// loop and release states used for envelopes
 		case AUDIO_STATE_PLAY_LOOP: {
-			word elapsed = millis() - this->_startTime;
+			uint32_t elapsed = millis() - this->_startTime;
 			if (isReleasing(elapsed)) {
 				debug_log("audio_driver: releasing...\n\r");
 				this->_state = AUDIO_STATE_RELEASE;
@@ -441,7 +441,7 @@ void audio_channel::loop() {
 			break;
 		}
 		case AUDIO_STATE_RELEASE: {
-			word elapsed = millis() - this->_startTime;
+			uint32_t elapsed = millis() - this->_startTime;
 			// update volume and frequency as appropriate
 			if (this->_volumeEnvelope)
 				this->_waveform->setVolume(this->getVolume(elapsed));

--- a/video/agon_keyboard.h
+++ b/video/agon_keyboard.h
@@ -1,7 +1,6 @@
 #ifndef AGON_KEYBOARD_H
 #define AGON_KEYBOARD_H
 
-#include <Arduino.h>
 #include <fabgl.h>
 
 #include "agon.h"
@@ -9,10 +8,10 @@
 
 fabgl::PS2Controller		_PS2Controller;		// The keyboard class
 
-byte			_keycode = 0;					// Last pressed key code
-byte			_modifiers = 0;					// Last pressed key modifiers
-int				kbRepeatDelay = 500;			// Keyboard repeat delay ms (250, 500, 750 or 1000)		
-int				kbRepeatRate = 100;				// Keyboard repeat rate ms (between 33 and 500)
+uint8_t			_keycode = 0;					// Last pressed key code
+uint8_t			_modifiers = 0;					// Last pressed key modifiers
+uint16_t		kbRepeatDelay = 500;			// Keyboard repeat delay ms (250, 500, 750 or 1000)		
+uint16_t		kbRepeatRate = 100;				// Keyboard repeat rate ms (between 33 and 500)
 
 // Get keyboard instance
 inline fabgl::Keyboard* getKeyboard() {
@@ -31,7 +30,7 @@ void setupKeyboard() {
 
 // Set keyboard layout
 //
-void setKeyboardLayout(int region) {
+void setKeyboardLayout(uint8_t region) {
 	auto kb = getKeyboard();
 	switch(region) {
 		case 1:	kb->setLayout(&fabgl::USLayout); break;
@@ -51,7 +50,7 @@ void setKeyboardLayout(int region) {
 // Get keyboard key presses
 // returns true only if there's a new keypress update
 //
-bool getKeyboardKey(byte *keycode, byte *modifiers, byte *vk, byte *down) {
+bool getKeyboardKey(uint8_t *keycode, uint8_t *modifiers, uint8_t *vk, uint8_t *down) {
 	auto kb = getKeyboard();
 	fabgl::VirtualKeyItem item;
 
@@ -117,7 +116,7 @@ bool getKeyboardKey(byte *keycode, byte *modifiers, byte *vk, byte *down) {
 
 // Simpler keyboard read for CP/M Terminal Mode
 //
-bool getKeyboardKey(byte *ascii) {
+bool getKeyboardKey(uint8_t *ascii) {
 	auto kb = getKeyboard();
 	fabgl::VirtualKeyItem item;
 
@@ -135,7 +134,7 @@ bool getKeyboardKey(byte *ascii) {
 
 // Wait for shift key to be released, then pressed (used for paged mode)
 // 
-bool wait_shiftkey(byte *ascii, byte* vk, byte* down) {
+bool wait_shiftkey(uint8_t *ascii, uint8_t* vk, uint8_t* down) {
 	auto kb = getKeyboard();
 	fabgl::VirtualKeyItem item;
 
@@ -160,7 +159,7 @@ bool wait_shiftkey(byte *ascii, byte* vk, byte* down) {
 	return true;
 }
 
-void getKeyboardState(int *repeatDelay, int *repeatRate, byte *ledState) {
+void getKeyboardState(uint16_t *repeatDelay, uint16_t *repeatRate, uint8_t *ledState) {
 	bool numLock;
 	bool capsLock;
 	bool scrollLock;
@@ -170,7 +169,7 @@ void getKeyboardState(int *repeatDelay, int *repeatRate, byte *ledState) {
     *repeatRate = kbRepeatRate;
 }
 
-void setKeyboardState(int delay, int rate, byte ledState) {
+void setKeyboardState(uint16_t delay, uint16_t rate, uint8_t ledState) {
 	auto kb = getKeyboard();
 	if (delay >= 250 && delay <= 1000) kbRepeatDelay = (delay / 250) * 250;	// In steps of 250ms
 	if (rate >=  33 && rate <=  500) kbRepeatRate  = rate;

--- a/video/agon_screen.h
+++ b/video/agon_screen.h
@@ -13,7 +13,7 @@ fabgl::VGAController		_VGAController64;	// VGA class - 64 colours
 
 fabgl::VGABaseController *	_VGAController;		// Pointer to the current VGA controller class (one of the above)
 
-int				_VGAColourDepth;				// Number of colours per pixel (2, 4, 8, 16 or 64)
+uint8_t			_VGAColourDepth;				// Number of colours per pixel (2, 4, 8, 16 or 64)
 bool			doubleBuffered = false;			// Disable double buffering by default
 
 
@@ -23,7 +23,7 @@ bool			doubleBuffered = false;			// Disable double buffering by default
 // Returns:
 // - A singleton instance of a VGAController class
 //
-fabgl::VGABaseController * getVGAController(int colours = _VGAColourDepth) {
+fabgl::VGABaseController * getVGAController(uint8_t colours = _VGAColourDepth) {
 	switch (colours) {
 		case  2: return _VGAController2.instance();
 		case  4: return _VGAController4.instance();
@@ -47,7 +47,7 @@ void updateRGB2PaletteLUT() {
 
 // Get current colour depth
 //
-inline int getVGAColourDepth() {
+inline uint8_t getVGAColourDepth() {
 	return _VGAColourDepth;
 }
 
@@ -56,8 +56,8 @@ inline int getVGAColourDepth() {
 // - l: The logical colour to change
 // - c: The new colour
 // 
-void setPaletteItem(int l, RGB888 c) {
-	int depth = getVGAColourDepth();
+void setPaletteItem(uint8_t l, RGB888 c) {
+	auto depth = getVGAColourDepth();
 	if (l < depth) {
 		switch (depth) {
 			case 2: _VGAController2.setPaletteItem(l, c); break;
@@ -77,7 +77,7 @@ void setPaletteItem(int l, RGB888 c) {
 // - 1: Invalid # of colours
 // - 2: Not enough memory for mode
 //
-int change_resolution(int colours, char * modeLine) {
+int8_t change_resolution(uint8_t colours, char * modeLine) {
 	auto controller = getVGAController(colours);
 
 	if (controller == nullptr) {					// If controller is null, then an invalid # of colours was passed
@@ -106,6 +106,12 @@ int change_resolution(int colours, char * modeLine) {
 	controller->enableBackgroundPrimitiveTimeout(false);
 
 	canvas = new fabgl::Canvas(controller);			// Create the new canvas
+	debug_log("after change of canvas...\n\r");
+	debug_log("  free internal: %d\n\r  free 8bit: %d\n\r  free 32bit: %d\n\r",
+		heap_caps_get_free_size(MALLOC_CAP_INTERNAL),
+		heap_caps_get_free_size(MALLOC_CAP_8BIT),
+		heap_caps_get_free_size(MALLOC_CAP_32BIT)
+	);
 	//
 	// Check whether the selected mode has enough memory for the vertical resolution
 	//

--- a/video/cursor.h
+++ b/video/cursor.h
@@ -2,24 +2,23 @@
 #define CURSOR_H
 
 #include <fabgl.h>
-#include <Arduino.h>
 
 #include "agon_keyboard.h"
 #include "vdp_protocol.h"
 #include "graphics.h"
 #include "viewport.h"
 
-extern int		fontW;
-extern int		fontH;
+extern uint8_t	fontW;
+extern uint8_t	fontH;
 extern void drawCursor(Point p);
-extern void scrollRegion(Rect * r, int direction, int amount);
+extern void scrollRegion(Rect * r, uint8_t direction, int16_t amount);
 
 Point			textCursor;						// Text cursor
 Point *			activeCursor;					// Pointer to the active text cursor (textCursor or p1)
 bool			cursorEnabled = true;			// Cursor visibility
-byte			cursorBehaviour = 0;			// Cursor behavior
+uint8_t			cursorBehaviour = 0;			// Cursor behavior
 bool 			pagedMode = false;				// Is output paged or not? Set by VDU 14 and 15
-int				pagedModeCount = 0;				// Scroll counter for paged mode
+uint8_t			pagedModeCount = 0;				// Scroll counter for paged mode
 
 
 // Render a cursor at the current screen position
@@ -42,7 +41,7 @@ inline void setActiveCursor(Point * cursor) {
 	activeCursor = cursor;
 }
 
-inline void setCursorBehaviour(byte setting, byte mask = 0xFF) {
+inline void setCursorBehaviour(uint8_t setting, uint8_t mask = 0xFF) {
 	cursorBehaviour = (cursorBehaviour & mask) ^ setting;
 }
 
@@ -72,12 +71,12 @@ void cursorDown() {
 		pagedModeCount++;
 		if (pagedModeCount >= (activeViewport->Y2 - activeViewport->Y1 + 1) / fontH) {
 			pagedModeCount = 0;
-			byte ascii;
-			byte vk;
-			byte down;
+			uint8_t ascii;
+			uint8_t vk;
+			uint8_t down;
 			if (!wait_shiftkey(&ascii, &vk, &down)) {
 				// ESC pressed
-				byte packet[] = {
+				uint8_t packet[] = {
 					ascii,
 					0,
 					vk,
@@ -140,7 +139,7 @@ void cursorHome() {
 
 // TAB(x,y)
 //
-void cursorTab(int x, int y) {
+void cursorTab(uint8_t x, uint8_t y) {
 	activeCursor->X = x * fontW;
 	activeCursor->Y = y * fontH;
 }

--- a/video/envelopes/frequency.h
+++ b/video/envelopes/frequency.h
@@ -12,8 +12,8 @@
 
 class FrequencyEnvelope {
 	public:
-		virtual uint16_t getFrequency(uint16_t baseFrequency, uint16_t elapsed, long duration);
-		virtual bool isFinished(uint16_t elapsed, long duration);
+		virtual uint16_t getFrequency(uint16_t baseFrequency, uint32_t elapsed, int32_t duration);
+		virtual bool isFinished(uint32_t elapsed, int32_t duration);
 };
 
 struct FrequencyStepPhase {
@@ -24,14 +24,14 @@ struct FrequencyStepPhase {
 class SteppedFrequencyEnvelope : public FrequencyEnvelope {
 	public:
 		SteppedFrequencyEnvelope(std::shared_ptr<std::vector<FrequencyStepPhase>> phases, uint16_t stepLength, bool repeats, bool cumulative, bool restrict);
-		uint16_t getFrequency(uint16_t baseFrequency, uint16_t elapsed, long duration);
-		bool isFinished(uint16_t elapsed, long duration);
+		uint16_t getFrequency(uint16_t baseFrequency, uint32_t elapsed, int32_t duration);
+		bool isFinished(uint32_t elapsed, int32_t duration);
 	private:
 		std::shared_ptr<std::vector<FrequencyStepPhase>> _phases;
-		long _stepLength;
-		int _totalSteps;
-		int _totalAdjustment;
-		int _totalLength;
+		uint16_t _stepLength;
+		uint32_t _totalSteps;
+		uint32_t _totalAdjustment;
+		uint32_t _totalLength;
 		bool _repeats;
 		bool _cumulative;
 		bool _restrict;
@@ -54,11 +54,11 @@ SteppedFrequencyEnvelope::SteppedFrequencyEnvelope(std::shared_ptr<std::vector<F
 	debug_log("audio_driver: SteppedFrequencyEnvelope: stepLength=%d, repeats=%d, restricts=%d, totalLength=%d\n\r", this->_stepLength, this->_repeats, this->_restrict, _totalLength);
 }
 
-uint16_t SteppedFrequencyEnvelope::getFrequency(uint16_t baseFrequency, uint16_t elapsed, long duration) {
+uint16_t SteppedFrequencyEnvelope::getFrequency(uint16_t baseFrequency, uint32_t elapsed, int32_t duration) {
 	// returns frequency for the given elapsed time
 	// a duration of -1 means we're playing forever
-	int currentStep = (elapsed / this->_stepLength) % this->_totalSteps;
-	int loopCount = elapsed / this->_totalLength;
+	auto currentStep = (elapsed / this->_stepLength) % this->_totalSteps;
+	auto loopCount = elapsed / this->_totalLength;
 
 	if (!_repeats && loopCount > 0) {
 		// we're not repeating and we've finished the envelope
@@ -66,7 +66,7 @@ uint16_t SteppedFrequencyEnvelope::getFrequency(uint16_t baseFrequency, uint16_t
 	}
 
 	// otherwise we need to calculate the frequency
-	int frequency = baseFrequency;
+	auto frequency = baseFrequency;
 
 	if (_cumulative) {
 		frequency += (loopCount * _totalAdjustment);
@@ -94,7 +94,7 @@ uint16_t SteppedFrequencyEnvelope::getFrequency(uint16_t baseFrequency, uint16_t
 	return frequency;
 }
 
-bool SteppedFrequencyEnvelope::isFinished(uint16_t elapsed, long duration) {
+bool SteppedFrequencyEnvelope::isFinished(uint32_t elapsed, int32_t duration) {
 	if (_repeats) {
 		// a repeating frequency envelope never finishes
 		return false;

--- a/video/envelopes/volume.h
+++ b/video/envelopes/volume.h
@@ -9,25 +9,25 @@
 
 class VolumeEnvelope {
 	public:
-		virtual byte getVolume(byte baseVolume, word elapsed, long duration);
-		virtual bool isReleasing(word elapsed, long duration);
-		virtual bool isFinished(word elapsed, long duration);
+		virtual uint8_t getVolume(uint8_t baseVolume, uint32_t elapsed, int32_t duration);
+		virtual bool isReleasing(uint32_t elapsed, int32_t duration);
+		virtual bool isFinished(uint32_t elapsed, int32_t duration);
 };
 
 class ADSRVolumeEnvelope : public VolumeEnvelope {
 	public:
-		ADSRVolumeEnvelope(word attack, word decay, byte sustain, word release);
-		byte getVolume(byte baseVolume, word elapsed, long duration);
-		bool isReleasing(word elapsed, long duration);
-		bool isFinished(word elapsed, long duration);
+		ADSRVolumeEnvelope(uint16_t attack, uint16_t decay, uint8_t sustain, uint16_t release);
+		uint8_t getVolume(uint8_t baseVolume, uint32_t elapsed, int32_t duration);
+		bool isReleasing(uint32_t elapsed, int32_t duration);
+		bool isFinished(uint32_t elapsed, int32_t duration);
 	private:
-		word _attack;
-		word _decay;
-		byte _sustain;
-		word _release;
+		uint16_t _attack;
+		uint16_t _decay;
+		uint8_t _sustain;
+		uint16_t _release;
 };
 
-ADSRVolumeEnvelope::ADSRVolumeEnvelope(word attack, word decay, byte sustain, word release)
+ADSRVolumeEnvelope::ADSRVolumeEnvelope(uint16_t attack, uint16_t decay, uint8_t sustain, uint16_t release)
 	: _attack(attack), _decay(decay), _sustain(sustain), _release(release)
 {
 	// attack, decay, release are time values in milliseconds
@@ -35,23 +35,23 @@ ADSRVolumeEnvelope::ADSRVolumeEnvelope(word attack, word decay, byte sustain, wo
 	debug_log("audio_driver: ADSRVolumeEnvelope: attack=%d, decay=%d, sustain=%d, release=%d\n\r", this->_attack, this->_decay, this->_sustain, this->_release);
 }
 
-byte ADSRVolumeEnvelope::getVolume(byte baseVolume, word elapsed, long duration) {
+uint8_t ADSRVolumeEnvelope::getVolume(uint8_t baseVolume, uint32_t elapsed, int32_t duration) {
 	// returns volume for the given elapsed time
 	// baseVolume is the level the attack phase should reach
 	// sustain volume level is calculated relative to baseVolume
 	// volume for fab-gl is 0-127 but accepts higher values, so we're not clamping
 	// a duration of -1 means we're playing forever
-	long phaseTime = elapsed;
+	auto phaseTime = elapsed;
 	if (phaseTime < this->_attack) {
 		return (phaseTime * baseVolume) / this->_attack;
 	}
 	phaseTime -= this->_attack;
-	byte sustainVolume = baseVolume * this->_sustain / 127;
+	uint8_t sustainVolume = baseVolume * this->_sustain / 127;
 	if (phaseTime < this->_decay) {
 		return map(phaseTime, 0, this->_decay, baseVolume, sustainVolume);
 	}
 	phaseTime -= this->_decay;
-	long sustainDuration = duration < 0 ? elapsed : duration - (this->_attack + this->_decay);
+	auto sustainDuration = duration < 0 ? elapsed : duration - (this->_attack + this->_decay);
 	if (sustainDuration < 0) sustainDuration = 0;
 	if (phaseTime < sustainDuration) {
 		return sustainVolume;
@@ -63,17 +63,17 @@ byte ADSRVolumeEnvelope::getVolume(byte baseVolume, word elapsed, long duration)
 	return 0;
 }
 
-bool ADSRVolumeEnvelope::isReleasing(word elapsed, long duration) {
+bool ADSRVolumeEnvelope::isReleasing(uint32_t elapsed, int32_t duration) {
 	if (duration < 0) return false;
-	word minDuration = this->_attack + this->_decay;
+	auto minDuration = this->_attack + this->_decay;
 	if (duration < minDuration) duration = minDuration;
 
 	return (elapsed >= duration);
 }
 
-bool ADSRVolumeEnvelope::isFinished(word elapsed, long duration) {
+bool ADSRVolumeEnvelope::isFinished(uint32_t elapsed, int32_t duration) {
 	if (duration < 0) return false;
-	word minDuration = this->_attack + this->_decay;
+	auto minDuration = this->_attack + this->_decay;
 	if (duration < minDuration) duration = minDuration;
 
 	return (elapsed >= duration + this->_release);

--- a/video/graphics.h
+++ b/video/graphics.h
@@ -17,9 +17,9 @@ fabgl::PaintOptions			tpo;				// Text paint options
 Point			p1, p2, p3;						// Coordinate store for plot
 RGB888			gfg, gbg;						// Graphics foreground and background colour
 RGB888			tfg, tbg;						// Text foreground and background colour
-int				fontW;							// Font width
-int				fontH;							// Font height
-int				videoMode;						// Current video mode
+uint8_t			fontW;							// Font width
+uint8_t			fontH;							// Font height
+uint8_t			videoMode;						// Current video mode
 bool			legacyModes = false;			// Default legacy modes being false
 uint8_t			palette[64];					// Storage for the palette
 
@@ -27,7 +27,7 @@ uint8_t			palette[64];					// Storage for the palette
 // VDU 23, 0, &86: Send MODE information (screen details)
 //
 void sendModeInformation() {
-	byte packet[] = {
+	uint8_t packet[] = {
 		canvasW & 0xFF,						// Width in pixels (L)
 		(canvasW >> 8) & 0xFF,				// Width in pixels (H)
 		canvasH & 0xFF,						// Height in pixels (L)
@@ -48,12 +48,12 @@ void copy_font() {
 
 // Redefine a character in the font
 //
-void redefineCharacter(int c, uint8_t * data) {
+void redefineCharacter(uint8_t c, uint8_t * data) {
 	memcpy(&fabgl::FONT_AGON_DATA[c * 8], data, 8);
 }
 
-bool cmpChar(uint8_t * c1, uint8_t *c2, int len) {
-	for (int i = 0; i < len; i++) {
+bool cmpChar(uint8_t * c1, uint8_t *c2, uint8_t len) {
+	for (uint8_t i = 0; i < len; i++) {
 		if (*c1++ != *c2++) {
 			return false;
 		}
@@ -63,7 +63,7 @@ bool cmpChar(uint8_t * c1, uint8_t *c2, int len) {
 
 // Try and match a character at given pixel position
 //
-char getScreenChar(int px, int py) {
+char getScreenChar(uint16_t px, uint16_t py) {
 	RGB888	pixel;
 	uint8_t	charRow;
 	uint8_t	charData[8];
@@ -79,9 +79,9 @@ char getScreenChar(int px, int py) {
 
 	// Now scan the screen and get the 8 byte pixel representation in charData
 	//
-	for (int y = 0; y < 8; y++) {
+	for (uint8_t y = 0; y < 8; y++) {
 		charRow = 0;
-		for (int x = 0; x < 8; x++) {
+		for (uint8_t x = 0; x < 8; x++) {
 			pixel = canvas->getPixel(px + x, py + y);
 			if (!(pixel.R == R && pixel.G == G && pixel.B == B)) {
 				charRow |= (0x80 >> x);
@@ -92,7 +92,7 @@ char getScreenChar(int px, int py) {
 	//
 	// Finally try and match with the character set array
 	//
-	for (int i = 32; i <= 255; i++) {
+	for (uint8_t i = 32; i <= 255; i++) {
 		if (cmpChar(charData, &fabgl::FONT_AGON_DATA[i * 8], 8)) {	
 			return i;		
 		}
@@ -102,7 +102,7 @@ char getScreenChar(int px, int py) {
 
 // Get pixel value at screen coordinates
 //
-RGB888 getPixel(int x, int y) {
+RGB888 getPixel(uint16_t x, uint16_t y) {
 	Point p = translateViewport(scale(x, y));
 	if (p.X >= 0 && p.Y >= 0 && p.X < canvasW && p.Y < canvasH) {
 		return canvas->getPixel(p.X, p.Y);
@@ -113,7 +113,7 @@ RGB888 getPixel(int x, int y) {
 // Get the palette index for a given RGB888 colour
 //
 uint8_t getPaletteIndex(RGB888 colour) {
-	for (int i = 0; i < getVGAColourDepth(); i++) {
+	for (uint8_t i = 0; i < getVGAColourDepth(); i++) {
 		if (colourLookup[palette[i]] == colour) {
 			return i;
 		}
@@ -129,7 +129,7 @@ uint8_t getPaletteIndex(RGB888 colour) {
 // - g: The green component
 // - b: The blue component
 //
-void setPalette(int l, int p, int r, int g, int b) {
+void setPalette(uint8_t l, uint8_t p, uint8_t r, uint8_t g, uint8_t b) {
 	RGB888 col;				// The colour to set
 
 	if (getVGAColourDepth() < 64) {		// If it is a paletted video mode
@@ -155,7 +155,7 @@ void setPalette(int l, int p, int r, int g, int b) {
 // - sizeOfArray: Size of passed colours array
 //
 void resetPalette(const uint8_t colours[]) {
-	for (int i = 0; i < 64; i++) {
+	for (uint8_t i = 0; i < 64; i++) {
 		uint8_t c = colours[i % getVGAColourDepth()];
 		palette[i] = c;
 		setPaletteItem(i, colourLookup[c]);
@@ -165,7 +165,7 @@ void resetPalette(const uint8_t colours[]) {
 
 // Get the paint options for a given GCOL mode
 //
-fabgl::PaintOptions getPaintOptions(int mode, fabgl::PaintOptions priorPaintOptions) {
+fabgl::PaintOptions getPaintOptions(uint8_t mode, fabgl::PaintOptions priorPaintOptions) {
 	fabgl::PaintOptions p = priorPaintOptions;
 	
 	switch (mode) {
@@ -177,8 +177,8 @@ fabgl::PaintOptions getPaintOptions(int mode, fabgl::PaintOptions priorPaintOpti
 
 // Set text colour (handles COLOUR / VDU 17)
 //
-void setTextColour(byte colour) {
-	byte c = palette[colour % getVGAColourDepth()];
+void setTextColour(uint8_t colour) {
+	uint8_t c = palette[colour % getVGAColourDepth()];
 
 	if (colour >= 0 && colour < 64) {
 		tfg = colourLookup[c];
@@ -195,8 +195,8 @@ void setTextColour(byte colour) {
 
 // Set graphics colour (handles GCOL / VDU 18)
 //
-void setGraphicsColour(byte mode, byte colour) {
-	byte c = palette[colour % getVGAColourDepth()];
+void setGraphicsColour(uint8_t mode, uint8_t colour) {
+	uint8_t c = palette[colour % getVGAColourDepth()];
 
 	if (mode >= 0 && mode <= 6) {
 		if (colour >= 0 && colour < 64) {
@@ -239,7 +239,7 @@ void pushPoint(Point p) {
 	p2 = p1;
 	p1 = p;
 }
-void pushPoint(short x, short y) {
+void pushPoint(uint16_t x, uint16_t y) {
 	pushPoint(translateViewport(scale(x, y)));
 }
 
@@ -277,7 +277,7 @@ void plotPoint() {
 
 // Triangle plot
 //
-void plotTriangle(byte mode) {
+void plotTriangle(uint8_t mode) {
 	Point p[3] = {
 		p3,
 		p2,
@@ -290,19 +290,18 @@ void plotTriangle(byte mode) {
 
 // Circle plot
 //
-void plotCircle(byte mode) {
-	int a, b, r;
+void plotCircle(uint8_t mode) {
 	switch (mode) {
-		case 0x00 ... 0x03: // Circle
-			r = 2 * (p1.X + p1.Y);
+		case 0x00 ... 0x03: { // Circle
+			auto r = 2 * (p1.X + p1.Y);
 			canvas->drawEllipse(p2.X, p2.Y, r, r);
-			break;
-		case 0x04 ... 0x07: // Circle
-			a = p2.X - p1.X;
-			b = p2.Y - p1.Y;
-			r = 2 * sqrt(a * a + b * b);
+		} break;
+		case 0x04 ... 0x07: { // Circle
+			auto a = p2.X - p1.X;
+			auto b = p2.Y - p1.Y;
+			auto r = 2 * sqrt(a * a + b * b);
 			canvas->drawEllipse(p2.X, p2.Y, r, r);
-		break;
+		} break;
 	}
 }
 
@@ -392,8 +391,8 @@ void clg() {
 // -  2: Not enough memory for mode
 // - -1: Invalid mode
 //
-int change_mode(int mode) {
-	int errVal = -1;
+int8_t change_mode(uint8_t mode) {
+	int8_t errVal = -1;
 
 	doubleBuffered = false;			// Default is to not double buffer the display
 
@@ -561,8 +560,8 @@ int change_mode(int mode) {
 // Parameters:
 // - mode: The video mode
 //
-void set_mode(int mode) {
-	int errVal = change_mode(mode);
+void set_mode(uint8_t mode) {
+	auto errVal = change_mode(mode);
 	if (errVal != 0) {
 		debug_log("set_mode: error %d\n\r", errVal);
 		errVal = change_mode(videoMode);
@@ -580,7 +579,7 @@ void setLegacyModes(bool legacy) {
 	legacyModes = legacy;
 }
 
-void scrollRegion(Rect * region, int direction, int movement) {
+void scrollRegion(Rect * region, uint8_t direction, int16_t movement) {
 	canvas->setScrollingRegion(region->X1, region->Y1, region->X2, region->Y2);
 
 	switch (direction) {

--- a/video/sprites.h
+++ b/video/sprites.h
@@ -1,7 +1,6 @@
 #ifndef SPRITES_H
 #define SPRITES_H
 
-#include <Arduino.h>
 #include <fabgl.h>
 
 #include "agon.h"
@@ -17,7 +16,7 @@ Bitmap * getBitmap(uint8_t b = current_bitmap) {
 	return &bitmaps[b];
 }
 
-void setCurrentBitmap(uint8_t b) {
+inline void setCurrentBitmap(uint8_t b) {
 	current_bitmap = b;
 }
 
@@ -34,13 +33,13 @@ void clearBitmap(uint8_t b = current_bitmap) {
 	bitmap->dataAllocated = false;
 }
 
-void createBitmap(int width, int height, void * data, PixelFormat format = PixelFormat::RGBA8888) {
+void createBitmap(uint16_t width, uint16_t height, void * data, PixelFormat format = PixelFormat::RGBA8888) {
 	clearBitmap();
 	bitmaps[current_bitmap] = Bitmap(width, height, (uint8_t *)data, format);
 	bitmaps[current_bitmap].dataAllocated = false;
 }
 
-void drawBitmap(int x, int y) {
+void drawBitmap(uint16_t x, uint16_t y) {
 	auto bitmap = getBitmap();
 	if (bitmap->data) {
 		canvas->drawBitmap(x, y, bitmap);
@@ -49,7 +48,7 @@ void drawBitmap(int x, int y) {
 }
 
 void resetBitmaps() {
-	for (int n = 0; n < MAX_BITMAPS; n++) {
+	for (uint8_t n = 0; n < MAX_BITMAPS; n++) {
 		clearBitmap(n);
 	}
 	waitPlotCompletion();
@@ -59,7 +58,7 @@ Sprite * getSprite(uint8_t sprite = current_sprite) {
 	return &sprites[sprite];
 }
 
-void setCurrentSprite(uint8_t s) {
+inline void setCurrentSprite(uint8_t s) {
 	current_sprite = s;
 }
 
@@ -95,7 +94,7 @@ void activateSprites(uint8_t n) {
 	waitPlotCompletion();
 }
 
-bool hasActiveSprites() {
+inline bool hasActiveSprites() {
 	return numsprites > 0;
 }
 
@@ -144,7 +143,7 @@ void refreshSprites() {
 }
 
 void resetSprites() {
-	for (int n = 0; n < MAX_SPRITES; n++) {
+	for (uint8_t n = 0; n < MAX_SPRITES; n++) {
 		clearSpriteFrames(n);
 	}
 	waitPlotCompletion();

--- a/video/types.h
+++ b/video/types.h
@@ -1,0 +1,171 @@
+//+--------------------------------------------------------------------------
+//
+// File:        types.h
+//
+// Original Source info:
+// NightDriverStrip - (c) 2023 Plummer's Software LLC.  All Rights Reserved.
+//
+// This file is part of the NightDriver software project.
+//
+//    NightDriver is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    NightDriver is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with Nightdriver.  It is normally found in copying.txt
+//    If not, see <https://www.gnu.org/licenses/>.
+//
+// Description:
+//
+//    Types of a somewhat general use
+//
+// History:     May-23-2023         Rbergen      Created
+//
+//---------------------------------------------------------------------------
+
+
+#pragma once
+
+#include <Arduino.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+
+// PreferPSRAMAlloc
+//
+// Will return PSRAM if it's available, regular ram otherwise
+
+inline void * PreferPSRAMAlloc(size_t s)
+{
+	if (psramInit())
+	{
+		debug_log("PSRAM Array Request for %u bytes\n", s);
+		return ps_malloc(s);
+	}
+	else
+	{
+		return malloc(s);
+	}
+}
+
+// psram_allocator
+//
+// A C++ allocator that allocates from PSRAM instead of the regular heap. Initially
+// I had just overloaded new for the classes I wanted in PSRAM, but that doesn't work
+// with make_shared<> so I had to provide this allocator instead.
+//
+// When enabled, this puts all of the LEDBuffers in PSRAM.  The table that keeps track
+// of them is still in base ram.
+//
+// (Davepl - I opted to make this *prefer* psram but return regular ram otherwise. It
+//           avoids a lot of ifdef USE_PSRAM in the code.  But I've only proved it
+//           correct, not tried it on a chip without yet.
+
+template <typename T>
+class psram_allocator
+{
+public:
+	typedef size_t size_type;
+	typedef ptrdiff_t difference_type;
+	typedef T* pointer;
+	typedef const T* const_pointer;
+	typedef T& reference;
+	typedef const T& const_reference;
+	typedef T value_type;
+
+	psram_allocator(){}
+	~psram_allocator(){}
+
+	template <class U> struct rebind { typedef psram_allocator<U> other; };
+	template <class U> psram_allocator(const psram_allocator<U>&){}
+
+	pointer address(reference x) const {return &x;}
+	const_pointer address(const_reference x) const {return &x;}
+	size_type max_size() const throw() {return size_t(-1) / sizeof(value_type);}
+
+	pointer allocate(size_type n, const void * hint = 0)
+	{
+		void * pmem = PreferPSRAMAlloc(n*sizeof(T));
+		return static_cast<pointer>(pmem) ;
+	}
+
+	void deallocate(pointer p, size_type n)
+	{
+		free(p);
+	}
+
+	template< class U, class... Args >
+	void construct( U* p, Args&&... args )
+	{
+		::new((void *) p ) U(std::forward<Args>(args)...);
+	}
+
+	void destroy(pointer p)
+	{
+		p->~T();
+	}
+};
+
+// Typically we do not need a deleter because the regular one can handle PSRAM deallocations just fine,
+// but for completeness, here it is.
+
+template<typename T>
+struct psram_deleter
+{
+	void operator()(T* ptr)
+	{
+		psram_allocator<T> allocator;
+		allocator.destroy(ptr);
+		allocator.deallocate(ptr, 1);
+	}
+};
+
+// make_unique_psram
+//
+// Like std::make_unique, but returns PSRAM instead of base RAM.  We cheat a little here by not providing
+// a deleter, because we know that PSRAM can be freed with the regular free() call and does not require
+// special handling.
+
+template<typename T, typename... Args>
+std::unique_ptr<T> make_unique_psram(Args&&... args)
+{
+	psram_allocator<T> allocator;
+	T* ptr = allocator.allocate(1);
+	allocator.construct(ptr, std::forward<Args>(args)...);
+	return std::unique_ptr<T>(ptr);
+}
+
+template<typename T>
+std::unique_ptr<T[]> make_unique_psram_array(size_t size)
+{
+	psram_allocator<T> allocator;
+	T* ptr = allocator.allocate(size);
+	// No need to call construct since arrays don't have constructors
+	return std::unique_ptr<T[]>(ptr);
+}
+
+// make_shared_psram
+//
+// Same as std::make_shared except allocates preferentially from the PSRAM pool
+
+template<typename T, typename... Args>
+std::shared_ptr<T> make_shared_psram(Args&&... args)
+{
+	psram_allocator<T> allocator;
+	return std::allocate_shared<T>(allocator, std::forward<Args>(args)...);
+}
+
+template<typename T>
+std::shared_ptr<T> make_shared_psram_array(size_t size)
+{
+	psram_allocator<T> allocator;
+	return std::allocate_shared<T>(allocator, size);
+}
+

--- a/video/vdp_protocol.h
+++ b/video/vdp_protocol.h
@@ -16,8 +16,6 @@
 
 #define VDPSerial Serial2
 
-#pragma once
-
 void setupVDPProtocol() {
 	VDPSerial.end();
 	VDPSerial.setRxBufferSize(UART_RX_SIZE);					// Can't be called when running

--- a/video/vdp_protocol.h
+++ b/video/vdp_protocol.h
@@ -30,7 +30,7 @@ inline bool byteAvailable() {
 	return VDPSerial.available() > 0;
 }
 
-inline byte readByte() {
+inline uint8_t readByte() {
 	return VDPSerial.read();
 }
 
@@ -42,9 +42,8 @@ inline void writeByte(byte b) {
 // Returns:
 // - Byte value (0 to 255) if value read, otherwise -1
 //
-int readByte_t() {
-	int	i;
-	unsigned long t = millis();
+int16_t readByte_t() {
+	auto t = millis();
 
 	while (millis() - t < 1000) {
 		if (byteAvailable()) {
@@ -58,10 +57,10 @@ int readByte_t() {
 // Returns:
 // - Word value (0 to 65535) if 2 bytes read, otherwise -1
 //
-int	readWord_t() {
-	int	l = readByte_t();
+uint32_t readWord_t() {
+	auto l = readByte_t();
 	if (l >= 0) {
-		int h = readByte_t();
+		auto h = readByte_t();
 		if (h >= 0) {
 			return (h << 8) | l;
 		}
@@ -73,12 +72,12 @@ int	readWord_t() {
 // Returns:
 // - Value (0 to 16777215) if 3 bytes read, otherwise -1
 //
-int	read24_t() {
-	int	l = readByte_t();
+uint32_t read24_t() {
+	auto l = readByte_t();
 	if (l >= 0) {
-		int m = readByte_t();
+		auto m = readByte_t();
 		if (m >= 0) {
-			int h = readByte_t();
+			auto h = readByte_t();
 			if (h >= 0) {
 				return (h << 16) | (m << 8) | l;
 			}
@@ -89,7 +88,7 @@ int	read24_t() {
 
 // Read an unsigned byte from the serial port (blocking)
 //
-byte readByte_b() {
+uint8_t readByte_b() {
   	while (VDPSerial.available() == 0);
   	return readByte();
 }
@@ -116,7 +115,7 @@ void discardBytes(int length) {
 
 // Send a packet of data to the MOS
 //
-void send_packet(byte code, byte len, byte data[]) {
+void send_packet(uint8_t code, uint16_t len, uint8_t data[]) {
 	writeByte(code + 0x80);
 	writeByte(len);
 	for (int i = 0; i < len; i++) {

--- a/video/vdu.h
+++ b/video/vdu.h
@@ -1,5 +1,3 @@
-#include <Arduino.h>
-
 #include "agon.h"
 #include "cursor.h"
 #include "graphics.h"
@@ -10,7 +8,7 @@
 // VDU 17 Handle COLOUR
 // 
 void vdu_colour() {
-	int		colour = readByte_t();
+	auto colour = readByte_t();
 
 	setTextColour(colour);
 }
@@ -18,8 +16,8 @@ void vdu_colour() {
 // VDU 18 Handle GCOL
 // 
 void vdu_gcol() {
-	int		mode = readByte_t();
-	int		colour = readByte_t();
+	auto mode = readByte_t();
+	auto colour = readByte_t();
 
 	setGraphicsColour(mode, colour);
 }
@@ -27,11 +25,11 @@ void vdu_gcol() {
 // VDU 19 Handle palette
 //
 void vdu_palette() {
-	int l = readByte_t(); if (l == -1) return; // Logical colour
-	int p = readByte_t(); if (p == -1) return; // Physical colour
-	int r = readByte_t(); if (r == -1) return; // The red component
-	int g = readByte_t(); if (g == -1) return; // The green component
-	int b = readByte_t(); if (b == -1) return; // The blue component
+	auto l = readByte_t(); if (l == -1) return; // Logical colour
+	auto p = readByte_t(); if (p == -1) return; // Physical colour
+	auto r = readByte_t(); if (r == -1) return; // The red component
+	auto g = readByte_t(); if (g == -1) return; // The green component
+	auto b = readByte_t(); if (b == -1) return; // The blue component
 
 	setPalette(l, p, r, g, b);
 }
@@ -39,7 +37,7 @@ void vdu_palette() {
 // VDU 22 Handle MODE
 //
 void vdu_mode() {
-	int mode = readByte_t();
+	auto mode = readByte_t();
 	debug_log("vdu_mode: %d\n\r", mode);
 	if (mode >= 0) {
 	  	set_mode(mode);
@@ -50,10 +48,10 @@ void vdu_mode() {
 // Example: VDU 24,640;256;1152;896;
 //
 void vdu_graphicsViewport() {
-	int x1 = readWord_t();			// Left
-	int y2 = readWord_t();			// Bottom
-	int x2 = readWord_t();			// Right
-	int y1 = readWord_t();			// Top
+	auto x1 = readWord_t();			// Left
+	auto y2 = readWord_t();			// Bottom
+	auto x2 = readWord_t();			// Right
+	auto y1 = readWord_t();			// Top
 
 	if (setGraphicsViewport(x1, y1, x2, y2)) {
 		debug_log("vdu_graphicsViewport: OK %d,%d,%d,%d\n\r", x1, y1, x2, y2);
@@ -65,10 +63,10 @@ void vdu_graphicsViewport() {
 // VDU 25 Handle PLOT
 //
 void vdu_plot() {
-	int mode = readByte_t(); if (mode == -1) return;
+	auto mode = readByte_t(); if (mode == -1) return;
 
-	int x = readWord_t(); if (x == -1) return; else x = (short)x;
-	int y = readWord_t(); if (y == -1) return; else y = (short)y;
+	auto x = readWord_t(); if (x == -1) return; else x = (short)x;
+	auto y = readWord_t(); if (y == -1) return; else y = (short)y;
 
 	pushPoint(x, y);
 	setGraphicsOptions();
@@ -108,10 +106,10 @@ void vdu_resetViewports() {
 // Example: VDU 28,20,23,34,4
 //
 void vdu_textViewport() {
-	int x1 = readByte_t() * fontW;				// Left
-	int y2 = (readByte_t() + 1) * fontH - 1;	// Bottom
-	int x2 = (readByte_t() + 1) * fontW - 1;	// Right
-	int y1 = readByte_t() * fontH;				// Top
+	auto x1 = readByte_t() * fontW;				// Left
+	auto y2 = (readByte_t() + 1) * fontH - 1;	// Bottom
+	auto x2 = (readByte_t() + 1) * fontW - 1;	// Right
+	auto y1 = readByte_t() * fontH;				// Top
 
 	if (setTextViewport(x1, y1, x2, y2)) {
 		ensureCursorInViewport(textViewport);
@@ -124,9 +122,9 @@ void vdu_textViewport() {
 // Handle VDU 29
 //
 void vdu_origin() {
-	int x = readWord_t();
+	auto x = readWord_t();
 	if (x >= 0) {
-		int y = readWord_t();
+		auto y = readWord_t();
 		if (y >= 0) {
 			setOrigin(x, y);
 			debug_log("vdu_origin: %d,%d\n\r", x, y);
@@ -137,9 +135,9 @@ void vdu_origin() {
 // VDU 30 TAB(x,y)
 //
 void vdu_cursorTab() {
-	int x = readByte_t();
+	auto x = readByte_t();
 	if (x >= 0) {
-		int y = readByte_t();
+		auto y = readByte_t();
 		if (y >= 0) {
 			cursorTab(x, y);
 		}
@@ -148,7 +146,7 @@ void vdu_cursorTab() {
 
 // Handle VDU commands
 //
-void vdu(byte c) {
+void vdu(uint8_t c) {
 	switch(c) {
 		case 0x04:	
 			// enable text cursor

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -27,7 +27,7 @@ std::array<std::shared_ptr<audio_sample>, MAX_AUDIO_SAMPLES> samples;	// Storage
 // Audio channel driver task
 //
 void audio_driver(void * parameters) {
-	int channel = *(int *)parameters;
+	uint8_t channel = *(uint8_t *)parameters;
 
 	audio_channels.at(channel) = std::make_shared<audio_channel>(channel);
 	while (true) {
@@ -36,7 +36,7 @@ void audio_driver(void * parameters) {
 	}
 }
 
-void init_audio_channel(int channel) {
+void init_audio_channel(uint8_t channel) {
 	xTaskCreatePinnedToCore(audio_driver,  "audio_driver",
 		4096,						// This stack size can be checked & adjusted by reading the Stack Highwater
 		&channel,					// Parameters
@@ -46,13 +46,13 @@ void init_audio_channel(int channel) {
 	);
 }
 
-void audioTaskAbortDelay(int channel) {
+void audioTaskAbortDelay(uint8_t channel) {
 	if (audioHandlers[channel]) {
 		xTaskAbortDelay(audioHandlers[channel]);
 	}
 }
 
-void audioTaskKill(int channel) {
+void audioTaskKill(uint8_t channel) {
 	if (audioHandlers[channel]) {
 		vTaskDelete(audioHandlers[channel]);
 		audioHandlers[channel] = nullptr;
@@ -68,7 +68,7 @@ void audioTaskKill(int channel) {
 void init_audio() {
 	audioHandlers.reserve(MAX_AUDIO_CHANNELS);
 	debug_log("init_audio: we have reserved %d channels\n\r", audioHandlers.capacity());
-	for (int i = 0; i < AUDIO_CHANNELS; i++) {
+	for (uint8_t i = 0; i < AUDIO_CHANNELS; i++) {
 		init_audio_channel(i);
 	}
 	SoundGenerator.play(true);
@@ -76,8 +76,8 @@ void init_audio() {
 
 // Send an audio acknowledgement
 //
-void sendAudioStatus(int channel, int status) {
-	byte packet[] = {
+void sendAudioStatus(uint8_t channel, uint8_t status) {
+	uint8_t packet[] = {
 		channel,
 		status,
 	};
@@ -86,13 +86,13 @@ void sendAudioStatus(int channel, int status) {
 
 // Channel enabled?
 //
-bool channelEnabled(byte channel) {
+bool channelEnabled(uint8_t channel) {
 	return channel >= 0 && channel < MAX_AUDIO_CHANNELS && audio_channels[channel];
 }
 
 // Play a note
 //
-word play_note(byte channel, byte volume, word frequency, word duration) {
+uint8_t play_note(uint8_t channel, uint8_t volume, uint16_t frequency, uint16_t duration) {
 	if (channelEnabled(channel)) {
 		return audio_channels[channel]->play_note(volume, frequency, duration);
 	}
@@ -101,7 +101,7 @@ word play_note(byte channel, byte volume, word frequency, word duration) {
 
 // Get channel status
 //
-byte getChannelStatus(byte channel) {
+uint8_t getChannelStatus(uint8_t channel) {
 	if (channelEnabled(channel)) {
 		return audio_channels[channel]->getStatus();
 	}
@@ -110,7 +110,7 @@ byte getChannelStatus(byte channel) {
 
 // Set channel volume
 //
-void setVolume(byte channel, byte volume) {
+void setVolume(uint8_t channel, uint8_t volume) {
 	if (channelEnabled(channel)) {
 		audio_channels[channel]->setVolume(volume);
 	}
@@ -118,7 +118,7 @@ void setVolume(byte channel, byte volume) {
 
 // Set channel frequency
 //
-void setFrequency(byte channel, word frequency) {
+void setFrequency(uint8_t channel, uint16_t frequency) {
 	if (channelEnabled(channel)) {
 		audio_channels[channel]->setFrequency(frequency);
 	}
@@ -126,7 +126,7 @@ void setFrequency(byte channel, word frequency) {
 
 // Set channel waveform
 //
-void setWaveform(byte channel, int8_t waveformType) {
+void setWaveform(uint8_t channel, int8_t waveformType) {
 	if (channelEnabled(channel)) {
 		auto channelRef = audio_channels[channel];
 		channelRef->setWaveform(waveformType, channelRef);
@@ -137,7 +137,7 @@ void setWaveform(byte channel, int8_t waveformType) {
 
 // Clear a sample
 //
-byte clearSample(byte sampleIndex) {
+uint8_t clearSample(uint8_t sampleIndex) {
 	debug_log("clearSample: sample %d\n\r", sampleIndex);
 	if (sampleIndex >= 0 && sampleIndex < MAX_AUDIO_SAMPLES) {
 		if (!samples[sampleIndex]) {
@@ -153,7 +153,7 @@ byte clearSample(byte sampleIndex) {
 
 // Load a sample
 //
-byte loadSample(byte sampleIndex, int length) {
+uint8_t loadSample(uint8_t sampleIndex, uint32_t length) {
 	debug_log("free mem: %d\n\r", heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
 	if (sampleIndex >= 0 && sampleIndex < MAX_AUDIO_SAMPLES) {
 		debug_log("loadSample: sample %d - length %d\n\r", sampleIndex, length);
@@ -167,7 +167,7 @@ byte loadSample(byte sampleIndex, int length) {
 
 		if (data) {
 			// read data into buffer
-			for (int n = 0; n < length; n++) sample->data[n] = readByte_b();
+			for (auto n = 0; n < length; n++) sample->data[n] = readByte_b();
 			sample->length = length;
 
 			samples[sampleIndex].reset(sample);
@@ -189,7 +189,7 @@ byte loadSample(byte sampleIndex, int length) {
 
 // Set channel volume envelope
 //
-void setVolumeEnvelope(byte channel, byte type) {
+void setVolumeEnvelope(uint8_t channel, uint8_t type) {
 	if (channelEnabled(channel)) {
 		switch (type) {
 			case AUDIO_ENVELOPE_NONE:
@@ -197,10 +197,10 @@ void setVolumeEnvelope(byte channel, byte type) {
 				debug_log("vdu_sys_audio: channel %d - volume envelope disabled\n\r", channel);
 				break;
 			case AUDIO_ENVELOPE_ADSR:
-				int attack = readWord_t();		if (attack == -1) return;
-				int decay = readWord_t();		if (decay == -1) return;
-				int sustain = readByte_t();		if (sustain == -1) return;
-				int release = readWord_t();		if (release == -1) return;
+				auto attack = readWord_t();		if (attack == -1) return;
+				auto decay = readWord_t();		if (decay == -1) return;
+				auto sustain = readByte_t();	if (sustain == -1) return;
+				auto release = readWord_t();	if (release == -1) return;
 				auto envelope = std::make_shared<ADSRVolumeEnvelope>(attack, decay, sustain, release);
 				audio_channels[channel]->setVolumeEnvelope(envelope);
 				break;
@@ -210,7 +210,7 @@ void setVolumeEnvelope(byte channel, byte type) {
 
 // Set channel frequency envelope
 //
-void setFrequencyEnvelope(byte channel, byte type) {
+void setFrequencyEnvelope(uint8_t channel, uint8_t type) {
 	if (channelEnabled(channel)) {
 		switch (type) {
 			case AUDIO_ENVELOPE_NONE:
@@ -218,13 +218,13 @@ void setFrequencyEnvelope(byte channel, byte type) {
 				debug_log("vdu_sys_audio: channel %d - frequency envelope disabled\n\r", channel);
 				break;
 			case AUDIO_FREQUENCY_ENVELOPE_STEPPED:
-				int phaseCount = readByte_t();	if (phaseCount == -1) return;
-				int control = readByte_t();		if (control == -1) return;
-				int stepLength = readWord_t();	if (stepLength == -1) return;
+				auto phaseCount = readByte_t();	if (phaseCount == -1) return;
+				auto control = readByte_t();		if (control == -1) return;
+				auto stepLength = readWord_t();	if (stepLength == -1) return;
 				auto phases = std::make_shared<std::vector<FrequencyStepPhase>>();
-				for (int n = 0; n < phaseCount; n++) {
-					int adjustment = readWord_t();	if (adjustment == -1) return;
-					int number = readWord_t();		if (number == -1) return;
+				for (auto n = 0; n < phaseCount; n++) {
+					auto adjustment = readWord_t();	if (adjustment == -1) return;
+					auto number = readWord_t();		if (number == -1) return;
 					phases->push_back(FrequencyStepPhase { (int16_t)adjustment, (uint16_t)number });
 				}
 				bool repeats = control & AUDIO_FREQUENCY_REPEATS;
@@ -240,14 +240,14 @@ void setFrequencyEnvelope(byte channel, byte type) {
 // Audio VDU command support (VDU 23, 0, &85, <args>)
 //
 void vdu_sys_audio() {
-	int channel = readByte_t();		if (channel == -1) return;
-	int command = readByte_t();		if (command == -1) return;
+	auto channel = readByte_t();		if (channel == -1) return;
+	auto command = readByte_t();		if (command == -1) return;
 
 	switch (command) {
 		case AUDIO_CMD_PLAY: {
-			int volume = readByte_t();		if (volume == -1) return;
-			int frequency = readWord_t();	if (frequency == -1) return;
-			int duration = readWord_t();	if (duration == -1) return;
+			auto volume = readByte_t();		if (volume == -1) return;
+			auto frequency = readWord_t();	if (frequency == -1) return;
+			auto duration = readWord_t();	if (duration == -1) return;
 
 			sendAudioStatus(channel, play_note(channel, volume, frequency, duration));
 		}	break;
@@ -257,19 +257,19 @@ void vdu_sys_audio() {
 		}	break;
 
 		case AUDIO_CMD_VOLUME: {
-			int volume = readByte_t();		if (volume == -1) return;
+			auto volume = readByte_t();		if (volume == -1) return;
 
 			setVolume(channel, volume);
 		}	break;
 
 		case AUDIO_CMD_FREQUENCY: {
-			int frequency = readWord_t();	if (frequency == -1) return;
+			auto frequency = readWord_t();	if (frequency == -1) return;
 
 			setFrequency(channel, frequency);
 		}	break;
 
 		case AUDIO_CMD_WAVEFORM: {
-			int waveform = readByte_t();	if (waveform == -1) return;
+			auto waveform = readByte_t();	if (waveform == -1) return;
 
 			// set waveform, interpretting waveform number as a signed 8-bit value
 			// to allow for negative values to be used as sample numbers
@@ -279,12 +279,12 @@ void vdu_sys_audio() {
 		case AUDIO_CMD_SAMPLE: {
 			// sample number is negative 8 bit number, and provided in channel number param
 			int8_t sampleNum = -(int8_t)channel - 1;	// convert to positive, ranged from zero
-			int action = readByte_t();		if (action == -1) return;
+			auto action = readByte_t();		if (action == -1) return;
 
 			switch (action) {
 				case AUDIO_SAMPLE_LOAD: {
 					// length as a 24-bit value
-					int length = read24_t();		if (length == -1) return;
+					auto length = read24_t();		if (length == -1) return;
 
 					sendAudioStatus(channel, loadSample(sampleNum, length));
 				}	break;
@@ -317,13 +317,13 @@ void vdu_sys_audio() {
 		}	break;
 
 		case AUDIO_CMD_ENV_VOLUME: {
-			int type = readByte_t();		if (type == -1) return;
+			auto type = readByte_t();		if (type == -1) return;
 
 			setVolumeEnvelope(channel, type);
 		}	break;
 
 		case AUDIO_CMD_ENV_FREQUENCY: {
-			int type = readByte_t();		if (type == -1) return;
+			auto type = readByte_t();		if (type == -1) return;
 
 			setFrequencyEnvelope(channel, type);
 		}	break;

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -161,15 +161,12 @@ uint8_t loadSample(uint8_t sampleIndex, uint32_t length) {
 		// Clear out existing sample
 		clearSample(sampleIndex);
 
-		auto sample = make_shared_psram<audio_sample>();
-
-		int8_t * data = (int8_t *) heap_caps_malloc(length, MALLOC_CAP_SPIRAM);
-		sample->data = data;
+		auto sample = make_shared_psram<audio_sample>(length);
+		auto data = sample->data;
 
 		if (data) {
 			// read data into buffer
 			for (auto n = 0; n < length; n++) sample->data[n] = readByte_b();
-			sample->length = length;
 			samples[sampleIndex] = sample;
 			debug_log("vdu_sys_audio: sample %d - data loaded, length %d\n\r", sampleIndex, sample->length);
 			return 1;

--- a/video/vdu_sprites.h
+++ b/video/vdu_sprites.h
@@ -5,12 +5,13 @@
 
 #include "sprites.h"
 #include "vdp_protocol.h"
+#include "types.h"
 
 void receiveBitmap(uint8_t cmd, uint16_t width, uint16_t height) {
 	//
 	// Allocate new heap data
 	//
-	void * dataptr = (void *)heap_caps_malloc(sizeof(uint32_t)*width*height, MALLOC_CAP_SPIRAM);
+	void * dataptr = PreferPSRAMAlloc(sizeof(uint32_t)*width*height);
 
 	if (dataptr != NULL) {                  
 		if (cmd == 1) {
@@ -30,7 +31,7 @@ void receiveBitmap(uint8_t cmd, uint16_t width, uint16_t height) {
 		}
 		// Create bitmap structure
 		//
-		createBitmap(width,height,dataptr);
+		createBitmap(width, height, dataptr);
 	}
 	else { 
 		//

--- a/video/vdu_sprites.h
+++ b/video/vdu_sprites.h
@@ -1,13 +1,12 @@
 #ifndef _VDU_SPRITES_H_
 #define _VDU_SPRITES_H_
 
-#include <Arduino.h>
 #include <fabgl.h>
 
 #include "sprites.h"
 #include "vdp_protocol.h"
 
-void receiveBitmap(int cmd, uint16_t width, uint16_t height) {
+void receiveBitmap(uint8_t cmd, uint16_t width, uint16_t height) {
 	//
 	// Allocate new heap data
 	//
@@ -18,7 +17,7 @@ void receiveBitmap(int cmd, uint16_t width, uint16_t height) {
 			//
 			// Read data to the new databuffer
 			//
-			for (int n = 0; n < width*height; n++) ((uint32_t *)dataptr)[n] = readLong_b();  
+			for (auto n = 0; n < width*height; n++) ((uint32_t *)dataptr)[n] = readLong_b();  
 			debug_log("vdu_sys_sprites: bitmap %d - data received - width %d, height %d\n\r", getCurrentBitmap(), width, height);
 		}
 		if (cmd == 2) {
@@ -26,7 +25,7 @@ void receiveBitmap(int cmd, uint16_t width, uint16_t height) {
 			//
 			// Define single color
 			//
-			for (int n = 0; n < width*height; n++) ((uint32_t *)dataptr)[n] = color;            
+			for (auto n = 0; n < width*height; n++) ((uint32_t *)dataptr)[n] = color;            
 			debug_log("vdu_sys_sprites: bitmap %d - set to solid color - width %d, height %d\n\r", getCurrentBitmap(), width, height);            
 		}
 		// Create bitmap structure
@@ -51,11 +50,11 @@ void receiveBitmap(int cmd, uint16_t width, uint16_t height) {
 // Sprite Engine
 //
 void vdu_sys_sprites(void) {
-	int cmd = readByte_t();
+	auto cmd = readByte_t();
 
-	switch(cmd) {
+	switch (cmd) {
 		case 0: {	// Select bitmap
-			int	rb = readByte_t();
+			auto	rb = readByte_t();
 			if (rb >= 0) {
 				setCurrentBitmap(rb);
 				debug_log("vdu_sys_sprites: bitmap %d selected\n\r", getCurrentBitmap());
@@ -64,16 +63,16 @@ void vdu_sys_sprites(void) {
 
 		case 1:		// Send bitmap data
 		case 2: {	// Define bitmap in single color
-			int rw = readWord_t(); if (rw == -1) return;
-			int rh = readWord_t(); if (rh == -1) return;
+			auto rw = readWord_t(); if (rw == -1) return;
+			auto rh = readWord_t(); if (rh == -1) return;
 
 			receiveBitmap(cmd, rw, rh);
 
 		}	break;
 
 		case 3: {	// Draw bitmap to screen (x,y)
-			int	rx = readWord_t(); if (rx == -1) return;
-			int ry = readWord_t(); if (ry == -1) return;
+			auto	rx = readWord_t(); if (rx == -1) return;
+			auto ry = readWord_t(); if (ry == -1) return;
 
 			drawBitmap(rx,ry);
 			debug_log("vdu_sys_sprites: bitmap %d draw command\n\r", getCurrentBitmap());
@@ -92,7 +91,7 @@ void vdu_sys_sprites(void) {
 		* 7) Refresh
 		*/
 		case 4: {	// Select sprite
-			int b = readByte_t(); if (b == -1) return;
+			auto b = readByte_t(); if (b == -1) return;
 			setCurrentSprite(b);
 			debug_log("vdu_sys_sprites: sprite %d selected\n\r", getCurrentSprite());
 		}	break;
@@ -103,13 +102,13 @@ void vdu_sys_sprites(void) {
 		}	break;
 
 		case 6:	{	// Add frame to sprite
-			int b = readByte_t(); if (b == -1) return;
+			auto b = readByte_t(); if (b == -1) return;
 			addSpriteFrame(b);
 			debug_log("vdu_sys_sprites: sprite %d - bitmap %d added as frame %d\n\r", getCurrentSprite(), b, getSprite()->framesCount-1);
 		}	break;
 
 		case 7:	{	// Active sprites to GDU
-			int b = readByte_t(); if (b == -1) return;
+			auto b = readByte_t(); if (b == -1) return;
 			activateSprites(b);
 			debug_log("vdu_sys_sprites: %d sprites activated\n\r", numsprites);
 		}	break;
@@ -125,7 +124,7 @@ void vdu_sys_sprites(void) {
 		}	break;
 
 		case 10: {	// Set current frame id on sprite
-			int b = readByte_t(); if (b == -1) return;
+			auto b = readByte_t(); if (b == -1) return;
 			setSpriteFrame(b);
 			debug_log("vdu_sys_sprites: sprite %d set to frame %d\n\r", getCurrentSprite(), b);
 		}	break;
@@ -141,15 +140,15 @@ void vdu_sys_sprites(void) {
 		}	break;
 
 		case 13: {	// Move sprite to coordinate on screen
-			int	rx = readWord_t(); if (rx == -1) return;
-			int ry = readWord_t(); if (ry == -1) return;
+			auto rx = readWord_t(); if (rx == -1) return;
+			auto ry = readWord_t(); if (ry == -1) return;
 			moveSprite(rx, ry);
 			debug_log("vdu_sys_sprites: sprite %d - move to (%d,%d)\n\r", getCurrentSprite(), rx, ry);
 		}	break;
 
 		case 14: {	// Move sprite by offset to current coordinate on screen
-			int	rx = readWord_t(); if (rx == -1) return;
-			int ry = readWord_t(); if (ry == -1) return;
+			auto rx = readWord_t(); if (rx == -1) return;
+			auto ry = readWord_t(); if (ry == -1) return;
 			moveSpriteBy(rx, ry);
 			debug_log("vdu_sys_sprites: sprite %d - move by offset (%d,%d)\n\r", getCurrentSprite(), rx, ry);
 		}	break;

--- a/video/video.ino
+++ b/video/video.ino
@@ -42,6 +42,7 @@
 // 30/06/2023:					+ Fixed vdu_sys_sprites to correctly discard serial input if bitmap allocation fails
 // 13/08/2023:					+ New video modes, mode change resets page mode
 
+#include <HardwareSerial.h>
 #include <fabgl.h>
 
 #define VERSION			1
@@ -86,7 +87,7 @@ void setup() {
 // The main loop
 //
 void loop() {
-	int count = 0;						// Generic counter, incremented every loop iteration
+	uint32_t count = 0;						// Generic counter, incremented every loop iteration
 	bool cursorVisible = false;
 	bool cursorState = false;
 
@@ -106,7 +107,7 @@ void loop() {
  				cursorState = false;
 				do_cursor();
 			}
-			byte c = readByte();
+			auto c = readByte();
 			vdu(c);
 		}
 		count++;
@@ -116,10 +117,10 @@ void loop() {
 // Handle the keyboard: BBC VDU Mode
 //
 void do_keyboard() {
-	byte keycode;
-	byte modifiers;
-	byte vk;
-	byte down;
+	uint8_t keycode;
+	uint8_t modifiers;
+	uint8_t vk;
+	uint8_t down;
 	if (getKeyboardKey(&keycode, &modifiers, &vk, &down)) {
 		// Handle some control keys
 		//
@@ -129,7 +130,7 @@ void do_keyboard() {
 		}
 		// Create and send the packet back to MOS
 		//
-		byte packet[] = {
+		uint8_t packet[] = {
 			keycode,
 			modifiers,
 			vk,
@@ -142,7 +143,7 @@ void do_keyboard() {
 // Handle the keyboard: CP/M Terminal Mode
 // 
 void do_keyboard_terminal() {
-	byte ascii;
+	uint8_t ascii;
 	if (getKeyboardKey(&ascii)) {
 		// send raw byte straight to z80
 		writeByte(ascii);
@@ -171,7 +172,7 @@ void debug_log(const char *format, ...) {
 	#if DEBUG == 1
 	va_list ap;
 	va_start(ap, format);
-	int size = vsnprintf(nullptr, 0, format, ap) + 1;
+	auto size = vsnprintf(nullptr, 0, format, ap) + 1;
 	if (size > 0) {
 		va_end(ap);
 		va_start(ap, format);
@@ -195,7 +196,7 @@ void switchTerminalMode() {
 }
 
 void print(char const * text) {
-	for (int i = 0; i < strlen(text); i++) {
+	for (auto i = 0; i < strlen(text); i++) {
 		vdu(text[i]);
 	}
 }

--- a/video/viewport.h
+++ b/video/viewport.h
@@ -9,8 +9,8 @@
 extern void setClippingRect(Rect r);
 
 Point			origin;							// Screen origin
-int				canvasW;						// Canvas width
-int				canvasH;						// Canvas height
+uint16_t		canvasW;						// Canvas width
+uint16_t		canvasH;						// Canvas height
 bool			logicalCoords = true;			// Use BBC BASIC logical coordinates
 double			logicalScaleX;					// Scaling factor for logical coordinates
 double			logicalScaleY;
@@ -30,7 +30,7 @@ void viewportReset() {
 	useViewports = false;
 }
 
-Rect * getViewport(byte type) {
+Rect * getViewport(uint8_t type) {
 	switch (type) {
 		case VIEWPORT_TEXT: return &textViewport;
 		case VIEWPORT_DEFAULT: return &defaultViewport;
@@ -40,13 +40,13 @@ Rect * getViewport(byte type) {
 	}
 }
 
-void setActiveViewport(byte type) {
+void setActiveViewport(uint8_t type) {
 	activeViewport = getViewport(type);
 }
 
 // Translate a point relative to the graphics viewport
 //
-Point translateViewport(int X, int Y) {
+Point translateViewport(uint16_t X, uint16_t Y) {
 	if (logicalCoords) {
 		return Point(graphicsViewport.X1 + (origin.X + X), graphicsViewport.Y2 - (origin.Y + Y));
 	}
@@ -58,7 +58,7 @@ Point translateViewport(Point p) {
 
 // Scale a point
 //
-Point scale(int X, int Y) {
+Point scale(uint16_t X, uint16_t Y) {
 	if (logicalCoords) {
 		return Point((double)X / logicalScaleX, (double)Y / logicalScaleY);
 	}
@@ -70,7 +70,7 @@ Point scale(Point p) {
 
 // Translate a point relative to the canvas
 //
-Point translateCanvas(int X, int Y) {
+Point translateCanvas(uint16_t X, uint16_t Y) {
 	if (logicalCoords) {
 		return Point(origin.X + X, (canvasH - 1) - (origin.Y + Y));
 	}
@@ -81,9 +81,9 @@ Point translateCanvas(Point p) {
 }
 
 // Set graphics viewport
-bool setGraphicsViewport(short x1, short y1, short x2, short y2) {
-	Point p1 = translateCanvas(scale(x1, y1));
-	Point p2 = translateCanvas(scale(x2, y2));
+bool setGraphicsViewport(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2) {
+	auto p1 = translateCanvas(scale(x1, y1));
+	auto p2 = translateCanvas(scale(x2, y2));
 
 	if (p1.X >= 0 && p2.X < canvasW && p1.Y >= 0 && p2.Y < canvasH && p2.X > p1.X && p2.Y > p1.Y) {
 		graphicsViewport = Rect(p1.X, p1.Y, p2.X, p2.Y);
@@ -95,7 +95,7 @@ bool setGraphicsViewport(short x1, short y1, short x2, short y2) {
 }
 
 // Set text viewport
-bool setTextViewport(short x1, short y1, short x2, short y2) {
+bool setTextViewport(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2) {
 	if (x2 >= canvasW) x2 = canvasW - 1;
 	if (y2 >= canvasH) y2 = canvasH - 1;
 


### PR DESCRIPTION
Change to use proper C++ data types, rather than Arduino aliases.

As part of this the use of data types has been rationalised, making use of the C++ `auto` operator, and picking more appropriate sizes of data elements.  This 

A custom C++ allocator has been added to help facilitate the use of PSRAM.  This was taken from [Dave Plummer's](https://www.youtube.com/@DavesGarage) [NightDriverStrip project](https://github.com/PlummersSoftwareLLC/NightDriverStrip).

Audio code has also been changed to make better use of PSRAM, and to use some slightly more efficient allocation techniques, such as swapping some uses of `std::array` to `std::unordered_map`