### PR TITLE
change cursor drawing to be time based

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -31,6 +31,8 @@
 
 #define GPIO_ITRP				17		// VSync Interrupt Pin - for reference only
 
+#define CURSOR_PHASE			800		// Cursor blink phase (ms)
+
 // Commands for VDU 23, 0, n
 //
 #define VDP_GP					0x80	// General poll data

--- a/video/video.ino
+++ b/video/video.ino
@@ -87,30 +87,28 @@ void setup() {
 // The main loop
 //
 void loop() {
-	uint32_t count = 0;						// Generic counter, incremented every loop iteration
-	bool cursorVisible = false;
-	bool cursorState = false;
+	bool drawCursor = false;
+	auto cursorTime = millis();
 
 	while (true) {
 		if (terminalMode) {
 			do_keyboard_terminal();
 			continue;
 		}
-		cursorVisible = ((count & 0xFFFF) == 0);
-		if (cursorVisible) {
-			cursorState = !cursorState;
+		if (millis() - cursorTime > CURSOR_PHASE) {
+			cursorTime = millis();
+			drawCursor = !drawCursor;
 			do_cursor();
 		}
 		do_keyboard();
 		if (byteAvailable()) {
-			if (cursorState) {
- 				cursorState = false;
+			if (drawCursor) {
+ 				drawCursor = false;
 				do_cursor();
 			}
 			auto c = readByte();
 			vdu(c);
 		}
-		count++;
 	}
 }
 


### PR DESCRIPTION
fixes an issue for the emulator where the cursor rapidly flashed as it runs on hardware faster than an ESP32