### PR TITLE
fix keyboard when busy

### DIFF
--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -21,6 +21,7 @@ class VDUStreamProcessor {
 		void send_packet(uint8_t code, uint16_t len, uint8_t data[]);
 
 		void processAllAvailable();
+		void processNext();
 
 		void vdu(uint8_t c);
 
@@ -161,6 +162,14 @@ void VDUStreamProcessor::send_packet(uint8_t code, uint16_t len, uint8_t data[])
 //
 void VDUStreamProcessor::processAllAvailable() {
 	while (byteAvailable()) {
+		vdu(readByte());
+	}
+}
+
+// Process next command from the stream
+//
+void VDUStreamProcessor::processNext() {
+	if (byteAvailable()) {
 		vdu(readByte());
 	}
 }

--- a/video/video.ino
+++ b/video/video.ino
@@ -109,7 +109,7 @@ void loop() {
 				drawCursor = false;
 				do_cursor();
 			}
-			processor->processAllAvailable();
+			processor->processNext();
 		}
 	}
 }


### PR DESCRIPTION
fixes an issue whereby if the z80 kept the VDP busy then keyboard input wouldn’t be picked up.

this meant that a BASIC program that had a loop continually drawing to the screen couldnt be escaped from