### PR TITLE
preliminary “inverse” plot support

### DIFF
--- a/video/graphics.h
+++ b/video/graphics.h
@@ -245,22 +245,27 @@ Point * getGraphicsCursor() {
 //
 void setGraphicsOptions(uint8_t mode) {
 	auto colourMode = mode & 0x03;
+	fabgl::PaintOptions p = gpo;
+
 	canvas->setClippingRect(graphicsViewport);
 	switch (colourMode) {
 		case 0: break;	// move command
 		case 1: {
 			// use fg colour
 			canvas->setPenColor(gfg);
-			canvas->setBrushColor(gfg);
 		} break;
-		case 2: break;	// logical inverse colour (not suported)
+		case 2: {
+			// logical inverse colour (not suported for all operations)
+			p.NOT = 1;
+			// fallback to use fg colour
+			canvas->setPenColor(gfg);
+		} break;
 		case 3: {
 			// use bg colour
 			canvas->setPenColor(gbg);
-			canvas->setBrushColor(gbg);
 		} break;
 	}
-	canvas->setPaintOptions(gpo);
+	canvas->setPaintOptions(p);
 }
 
 // Set up canvas for drawing filled graphics

--- a/video/vdu.h
+++ b/video/vdu.h
@@ -185,13 +185,8 @@ void VDUStreamProcessor::vdu_plot() {
 			// move to modes
 			moveTo();
 			break;
-		case 2:
-		case 6:
-			// draw inverse logical colour not supported
-			debug_log("plot inverse logical colour not implemented\n\r");
-			break;
 		default:
-			// 1, 3, 5, 7 are all draw modes
+			// 1, 2, 3, 5, 6, 7 are all draw modes
 			switch (operation) {
 				case 0x00: 	// line
 					plotLine();


### PR DESCRIPTION
fab-gl’s canvas supports a NOT operation for line drawing, so expose that as our “logical inverse” plot