### PR TITLE
implement readIntoBuffer

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -26,7 +26,7 @@
 #define UART_RTS				13		// The ESP32 RTS pin (eZ80 CTS)
 #define UART_CTS	 			14		// The ESP32 CTS pin (eZ80 RTS)
 
-#define COMMS_TIMEOUT			100		// Timeout for VDP commands (ms)
+#define COMMS_TIMEOUT			200		// Timeout for VDP commands (ms)
 
 #define UART_RX_SIZE			256		// The RX buffer size
 #define UART_RX_THRESH			128		// Point at which RTS is toggled

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -152,7 +152,12 @@ uint8_t VDUStreamProcessor::loadSample(uint8_t sampleIndex, uint32_t length) {
 
 		if (data) {
 			// read data into buffer
-			for (auto n = 0; n < length; n++) sample->data[n] = readByte_b();
+			auto remaining = readIntoBuffer((uint8_t *)data, length);
+			if (remaining != 0) {
+				// Failed to read all data
+				debug_log("vdu_sys_audio: sample %d - data discarded, failed to read all data\n\r", sampleIndex);
+				return 0;
+			}
 			samples[sampleIndex] = sample;
 			debug_log("vdu_sys_audio: sample %d - data loaded, length %d\n\r", sampleIndex, sample->length);
 			return 1;

--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -67,9 +67,11 @@ void VDUStreamProcessor::bufferWrite(uint16_t bufferId) {
 
 	debug_log("bufferWrite: storing stream into buffer %d, length %d\n\r", bufferId, length);
 
-	for (auto i = 0; i < length; i++) {
-		auto data = readByte_b();
-		bufferStream->writeBufferByte(data, i);
+	auto remaining = readIntoBuffer(bufferStream->getBuffer(), length);
+	if (remaining > 0) {
+		// NB this discards the data we just read
+		debug_log("bufferWrite: timed out write for buffer %d (%d bytes remaining)\n\r", bufferId, remaining);
+		return;
 	}
 
 	buffers[bufferId].push_back(std::move(bufferStream));

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -163,9 +163,13 @@ void VDUStreamProcessor::vdu_sys_video() {
 // VDU 23, 0, &80, <echo>: Send a general poll/echo byte back to MOS
 //
 void VDUStreamProcessor::sendGeneralPoll() {
-	auto b = readByte_b();
+	auto b = readByte_t();
+	if (b == -1) {
+		debug_log("sendGeneralPoll: Timeout\n\r");
+		return;
+	}
 	uint8_t packet[] = {
-		b,
+		(uint8_t) (b & 0xFF),
 	};
 	send_packet(PACKET_GP, sizeof packet, packet);
 	initialised = true;	


### PR DESCRIPTION
and remove _most_ blocking reads
- only remaining ones are inside `hexload.h`

`discardBytes` is also now non-blocking, so except for the use noted above this PR addresses #35 