### PR TITLE
Add updater to receive firmware via UART serial link from ez80.

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -50,6 +50,8 @@
 #define VDP_LOGICALCOORDS		0xC0	// Switch BBC Micro style logical coords on and off
 #define VDP_LEGACYMODES			0xC1	// Switch VDP 1.03 compatible modes on and off
 #define VDP_SWITCHBUFFER		0xC3	// Double buffering control
+#define VDP_UPDATE				0xD0	// Update VDP
+#define VDP_SWITCH				0xD1	// Switch VDP
 #define VDP_TERMINALMODE		0xFF	// Switch to terminal mode
 
 // And the corresponding return packets

--- a/video/updater.h
+++ b/video/updater.h
@@ -1,0 +1,160 @@
+#ifndef UPDATER_H
+#define UPDATER_H
+
+#include "vdu_stream_processor.h"
+#include <cstdint>
+#include "esp_ota_ops.h"
+
+extern void printFmt(const char *format, ...);
+extern void print(const char * text);
+
+namespace Updater {
+	static constexpr uint8_t unlockCode[] = "unlock";
+	static bool isLocked = true;
+}
+
+void VDUStreamProcessor::unlock() {
+	uint8_t buffer[sizeof(Updater::unlockCode)] = {0};
+	uint32_t bytes_remain = readIntoBuffer(buffer, sizeof(buffer) - 1);
+	if(bytes_remain) {
+		printFmt("Read unlock code failed!\n\r");
+		return;
+	}
+	else if(memcmp(buffer, Updater::unlockCode, sizeof(Updater::unlockCode)) == 0) {
+		printFmt("Updater unlocked!\n\r");
+		Updater::isLocked = false;
+		return;
+	}
+}
+
+void VDUStreamProcessor::receiveFirmware() {
+	uint32_t update_size = 0;
+	uint32_t bytes_remain = readIntoBuffer((uint8_t*)&update_size, sizeof(update_size) - 1); // -1 because its 24bits
+	if(bytes_remain) {
+		printFmt("Read size failed!\n\r");
+		return;
+	}
+
+	if(Updater::isLocked) {
+		printFmt("Updater is locked, bytes will be discarded!\n\r");
+		discardBytes(update_size + 1);
+		return;
+	}
+	
+	printFmt("Received update size: %u bytes\n\r", update_size);
+
+	printFmt("Receiving VDP firmware update");
+
+	uint32_t start = millis();
+
+	esp_err_t err;
+	esp_ota_handle_t update_handle = 0 ;
+	const esp_partition_t *update_partition = NULL;
+	const esp_partition_t *configured = esp_ota_get_boot_partition();
+	const esp_partition_t *running = esp_ota_get_running_partition();
+
+	update_partition = esp_ota_get_next_update_partition(NULL);
+	err = esp_ota_begin(update_partition, OTA_SIZE_UNKNOWN, &update_handle);
+	if (err != ESP_OK) {
+		printFmt("esp_ota_begin failed, error=%d\n\r", err);
+	}
+
+	uint32_t remaining_bytes = update_size;
+	uint8_t code = 0;
+	const size_t buffer_size = 1024;
+
+	while(remaining_bytes > 0) {
+
+		size_t bytes_to_read = buffer_size;
+
+		if(remaining_bytes < buffer_size)
+		{
+			bytes_to_read = remaining_bytes;
+		}
+
+		uint8_t buffer[buffer_size];
+
+		bytes_remain = readIntoBuffer(buffer, bytes_to_read);
+		if(bytes_remain) {
+			printFmt("Read buffer failed at byte %u!\n\r", remaining_bytes);
+			break;
+		}
+
+		for(int i = 0; i < bytes_to_read; i++) {
+			code += ((uint8_t*)buffer)[i];
+		}
+
+		err = esp_ota_write( update_handle, (const void *)buffer, bytes_to_read);
+		if (err != ESP_OK) {
+			printFmt("esp_ota_write failed, error=%d", err);
+			break;
+		}
+
+		print(".");
+		remaining_bytes -= bytes_to_read;
+	}
+	print("\n\r");
+	
+	uint32_t end = millis();
+	printFmt("Upload done in %u ms\n\r", end - start);
+	printFmt("Bandwidth: %u kbit/s\n\r", update_size / (end - start) * 8);
+	
+	// checksum check
+	uint8_t checksum_complement = readByte_b();
+	printFmt("checksum_complement: 0x%x\n\r", checksum_complement);
+	if(uint8_t(code + checksum_complement)) {
+		printFmt("checksum error!\n\r");
+		return;
+	}
+	printFmt("checksum ok!\n\r");
+
+	err = esp_ota_set_boot_partition(update_partition);
+	if (err != ESP_OK) {
+		printFmt("esp_ota_set_boot_partition failed! err=0x%x\n\r", err);
+		return;
+	}
+
+	print("Rebooting in ");
+	for(int i = 3; i > 0; i--) {
+		printFmt("%d...", i);
+		delay(1000);
+	}
+	print("0!\n\r");
+	
+	esp_restart();
+}
+
+void VDUStreamProcessor::switchFirmware() {
+	if (Updater::isLocked) {
+		printFmt("Updater is locked!\n\r");
+		return;
+	}
+
+	esp_err_t err;
+	const esp_partition_t *running = esp_ota_get_running_partition();
+	const esp_partition_t *update_partition = esp_ota_get_next_update_partition(running);
+
+	err = esp_ota_set_boot_partition(update_partition);
+	if (err != ESP_OK) {
+		printFmt("esp_ota_set_boot_partition failed! err=0x%x\n\r", err);
+	}
+	printFmt("restart!\n\r");
+	esp_restart();
+}
+
+void VDUStreamProcessor::vdu_sys_updater() {
+	auto mode = readByte_t();
+	switch(mode) {
+		case 0: {
+			unlock();
+		} break;
+		case 1: {
+			receiveFirmware();
+		} break;
+		case 2: {
+			switchFirmware();
+		} break;
+	}
+}
+
+#endif // UPDATER_H

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -82,6 +82,11 @@ class VDUStreamProcessor {
 		void bufferReverseBlocks(uint16_t bufferId);
 		void bufferReverse(uint16_t bufferId, uint8_t options);
 
+		void vdu_sys_updater();
+		void unlock();
+		void receiveFirmware();
+		void switchFirmware();
+
 	public:
 		uint16_t id = 65535;
 

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -11,6 +11,7 @@
 #include "vdu_audio.h"
 #include "vdu_buffered.h"
 #include "vdu_sprites.h"
+#include "updater.h"
 
 extern void switchTerminalMode();				// Switch to terminal mode
 
@@ -36,6 +37,10 @@ typedef union {
 // Wait for eZ80 to initialise
 //
 void VDUStreamProcessor::wait_eZ80() {
+	if(esp_reset_reason() == ESP_RST_SW) {
+		return;
+	}
+
 	debug_log("wait_eZ80: Start\n\r");
 	while (!initialised) {
 		if (byteAvailable()) {
@@ -85,6 +90,9 @@ void VDUStreamProcessor::vdu_sys() {
 			}	break;
 			case 0x1C: {					// VDU 23, 28
 				vdu_sys_hexload();
+			}	break;
+			case 0x1D: {					// VDU 23, 29
+				vdu_sys_updater();
 			}	break;
 		}
 	}


### PR DESCRIPTION
This code leverages the ESP32 OTA functions to enable the ez80 to upload VDP firmware binaries. They get written to a second partition on the ESP32 flash and then the bootselector gets changed to this partition and the ESP32 restarts itself.
Another great feature is switching between two VDP versions without uploading anything new, just by changing the bootselector.

For safety reasons this module contains a knockcode. You first have to send a specific byte sequence to unlock it. Otherwise it would be possible to switch the bootselector by accident. The firmware upload is already secured by a mandatory checksum, but better be safer. :)

Current commands:
`VDU 23 29 0 117 110 108 111 99 107` unlocks the updater. Code is "unlock".
`VDU 23 29 1 <24bit filesize> <n data bytes> <single byte checksum>` To upload a firmware binary.
`VDU 23 29 2` to toggle between the two partitions.

This can be now used with the official agon-flash tool: https://github.com/envenomator/agon-flash
