### PR TITLE
Accepting segment records (type 02), warnings against overlapping ROM area addresses

### DIFF
--- a/video/hexload.h
+++ b/video/hexload.h
@@ -42,20 +42,25 @@ void echo_checksum(uint8_t ihexchecksum, uint8_t ez80checksum) {
 }
 
 void VDUStreamProcessor::vdu_sys_hexload(void) {
-	uint8_t u,h,l;
+	uint32_t segment_address;
+	uint8_t u,h,l,tmp;
 	uint8_t bytecount;
 	uint8_t recordtype;
 	uint8_t data;
 	uint8_t ihexchecksum,ez80checksum;
 
-	bool done,defaultaddress;
+	bool done,printdefaultaddress,segmentmode,no_startrecord;
+	bool rom_area;
 	uint16_t errorcount;
 
 	printFmt("Receiving Intel HEX records - VDP:%d 8N1\r\n\r\n", SERIALBAUDRATE);
 	u = DEF_U_BYTE;
 	errorcount = 0;
 	done = false;
-	defaultaddress = true;
+	printdefaultaddress = true;
+	segmentmode = false;
+	no_startrecord = false;
+	rom_area = false;
 
 	while(!done) {
 		data = 0;
@@ -67,13 +72,20 @@ void VDUStreamProcessor::vdu_sys_hexload(void) {
 		recordtype = getIHexByte(); // record type
 
 		ihexchecksum = bytecount + h + l + recordtype;  // init control checksum
+		if(segmentmode) {
+			//seg_effective_address += (((uint32_t)h << 8) | l);
+			u = ((segment_address + (((uint32_t)h << 8) | l)) & 0xFF0000) >> 16;
+			h = ((segment_address + (((uint32_t)h << 8) | l)) & 0xFF00) >> 8;
+			l = (segment_address + (((uint32_t)h << 8) | l)) & 0xFF;
+		}
 		ez80checksum = 1 + u + h + l + bytecount; 		// to be transmitted as a potential packet to the ez80
 
 		switch(recordtype) {
 			case 0: // data record
-				if(defaultaddress) {
+				if(printdefaultaddress) {
 					printFmt("\r\nAddress 0x%02x0000 (default)\r\n", DEF_U_BYTE);
-					defaultaddress = false;
+					printdefaultaddress = false;
+					no_startrecord = true;
 				}
 				sendKeycodeByte(1, true);			// ez80 data-package start indicator
 				sendKeycodeByte(u, true);      		// transmit full address in each package  
@@ -89,7 +101,33 @@ void VDUStreamProcessor::vdu_sys_hexload(void) {
 				ez80checksum += readByte_b();		// get feedback from ez80 - a 2s complement to the sum of all received bytes, total 0 if no errorcount      
 				ihexchecksum += getIHexByte();		// finalize checksum with actual checksum byte in record, total 0 if no errorcount
 				if(ihexchecksum || ez80checksum) errorcount++;
-				echo_checksum(ihexchecksum,ez80checksum);
+				if(u >= DEF_U_BYTE) echo_checksum(ihexchecksum,ez80checksum);
+				else printFmt("R");
+				break;
+			case 2: // Extended Segment Address record
+				printdefaultaddress = false;
+				segmentmode = true;
+				tmp = getIHexByte();              // segment 16-bit base address MSB
+				ihexchecksum += tmp;
+				segment_address = tmp << 8;
+				tmp = getIHexByte();              // segment 16-bit base address LSB
+				ihexchecksum += tmp;
+				segment_address |= tmp;
+				segment_address = segment_address << 4; // resulting segment base address in 20-bit space
+						ihexchecksum += getIHexByte();		// finalize checksum with actual checksum byte in record, total 0 if no errorcount
+						if(ihexchecksum) errorcount++;
+						echo_checksum(ihexchecksum,0);		// only echo local checksum errorcount, no ez80<=>ESP packets in this case
+
+				if(no_startrecord) {
+					printFmt("\r\nSegment address 0x%06X", segment_address);
+					segment_address += DEF_LOAD_ADDRESS;
+					printFmt(" - effective 0x%06X\r\n", segment_address);
+				}
+				else printFmt("\r\nAddress 0x%06X\r\n", segment_address);
+						if(segment_address < DEF_LOAD_ADDRESS) {
+					printFmt("ERROR: Address in ROM area\r\n", segment_address);
+					rom_area = true;
+				}
 				break;
 			case 1: // end of file record
 				getIHexByte();
@@ -97,14 +135,19 @@ void VDUStreamProcessor::vdu_sys_hexload(void) {
 				done = true;
 				break;
 			case 4: // extended linear address record, only update U byte for next transmission to the ez80
-				defaultaddress = false;
+				printdefaultaddress = false;
+				segmentmode = false;
 				ihexchecksum += getIHexByte();		// ignore top byte of 32bit address, only using 24bit
 				u = getIHexByte();
 				ihexchecksum += u;
 				ihexchecksum += getIHexByte();		// finalize checksum with actual checksum byte in record, total 0 if no errorcount
 				if(ihexchecksum) errorcount++;
 				echo_checksum(ihexchecksum,0);		// only echo local checksum errorcount, no ez80<=>ESP packets in this case
-				printFmt("\r\nAddress 0x%02x0000\r\n", u);
+				if(u >= DEF_U_BYTE) printFmt("\r\nAddress 0x%02X0000\r\n", u);
+				else {
+					printFmt("\r\nERROR: Address 0x%02X0000 in ROM area\r\n", u);
+					rom_area = true;
+				}
 				break;
 			default: // ignore other (non I32Hex) records
 				break;
@@ -114,7 +157,8 @@ void VDUStreamProcessor::vdu_sys_hexload(void) {
 		printFmt("\r\n%d error(s)\r\n",errorcount);
 	}
 	else {
-		printFmt("\r\nOK\r\n");
+		if(rom_area) printFmt("\r\nHEX data overlapping ROM area, transfer unsuccessful\r\nERROR\r\n");
+		else printFmt("\r\nOK\r\n");
 	}
 	printFmt("VDP done\r\n");   
 }


### PR DESCRIPTION
The VDP hexload code now accepts the less frequently used type 02 record, using 20-bit segment addresses. I found that the objcopy tool, when not passing it a start-address parameter, emits these records at each 64KB boundary.
Reading the original Intel hex specification, it appears that tools <may> use these type of records, originally meant for cpu's with a 20bit address space. Latter tools mostly use 32-bit addresses.

Also now displaying errors to the user when the uploaded hex file partly overlaps with the ROM/flash area. Users tend to forget to -offset their hex codes, when converting a binary file without address meta-data, which then lands starting at address 0 (rom/flash area).

When omitting the first address record in a hex-file, the tool previously already set the start-address to 0x40000. But when tools emit a 02 type record at the 64KB boundary to address 0x50000, they send 0x10000, because that is the sequential next address. Hexload now checks for a missing first address record and calculates the effective address when using record type 02 at each next 64KB boundary.
