### PR TITLE
Specify espressif32 to v6.4.0

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 src_dir = video
 
 [env:esp32dev]
-platform = espressif32
+platform = espressif32@6.4.0
 board = esp32dev
 framework = arduino
 lib_deps =


### PR DESCRIPTION
This is just to make sure we are using the same version of espressif32 platform. Its the current release: https://github.com/platformio/platform-espressif32/releases