### PR TITLE
Specify board settings for cpu and flash speed.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -14,6 +14,9 @@ src_dir = video
 [env:esp32dev]
 platform = espressif32
 board = esp32dev
+board_build.flash_mode = qio
+board_build.f_cpu = 240000000L
+board_build.f_flash = 80000000L
 framework = arduino
 lib_deps =
     https://github.com/avalonbits/vdp-gl.git#1.0.3


### PR DESCRIPTION
It looks like platformio builds with 40MHz flash speed default. I verified this by the checksum of the generated bootloader.bin:

default 8649c816ab7ba68aa0ea4c98bb25ae3a  bootloader.bin
40mhz 8649c816ab7ba68aa0ea4c98bb25ae3a  bootloader.bin
80mhz 03b32c0cabcc0c857bc2ae029a696d68  bootloader.bin