### PR TITLE
fix VDU 24

### DIFF
--- a/video/graphics.h
+++ b/video/graphics.h
@@ -93,7 +93,7 @@ char getScreenChar(uint16_t px, uint16_t py) {
 // Get pixel value at screen coordinates
 //
 RGB888 getPixel(uint16_t x, uint16_t y) {
-	Point p = translateViewport(scale(x, y));
+	Point p = translateCanvas(scale(x, y));
 	if (p.X >= 0 && p.Y >= 0 && p.X < canvasW && p.Y < canvasH) {
 		return canvas->getPixel(p.X, p.Y);
 	}
@@ -242,7 +242,7 @@ void pushPoint(Point p) {
 	p1 = p;
 }
 void pushPoint(uint16_t x, uint16_t y) {
-	pushPoint(translateViewport(scale(x, y)));
+	pushPoint(translateCanvas(scale(x, y)));
 }
 void pushPointRelative(int16_t x, int16_t y) {
 	auto scaledPoint = scale(x, y);

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -375,7 +375,7 @@ void VDUStreamProcessor::vdu_sys_mouse() {
 			auto x = readWord_t();	if (x == -1) return;
 			auto y = readWord_t();	if (y == -1) return;
 			// normalise coordinates
-			auto p = translateViewport(scale(x, y));
+			auto p = translateCanvas(scale(x, y));
 
 			// need to update position in mouse status
 			setMousePos(p.X, p.Y);

--- a/video/viewport.h
+++ b/video/viewport.h
@@ -44,18 +44,6 @@ void setActiveViewport(uint8_t type) {
 	activeViewport = getViewport(type);
 }
 
-// Translate a point relative to the graphics viewport
-//
-Point translateViewport(int16_t X, int16_t Y) {
-	if (logicalCoords) {
-		return Point(graphicsViewport.X1 + (origin.X + X), graphicsViewport.Y2 - (origin.Y + Y));
-	}
-	return Point(graphicsViewport.X1 + (origin.X + X), graphicsViewport.Y1 + (origin.Y + Y));
-}
-Point translateViewport(Point p) {
-	return translateViewport(p.X, p.Y);
-}
-
 // Scale a point
 //
 Point scale(int16_t X, int16_t Y) {


### PR DESCRIPTION
VDU 24 sets the graphics viewport.  essentially it sets a clipping rectangle, and that should be all it does…

this fixes a bug whereby setting the graphics viewport would also effectively change the graphics origin.  this is contrary to how Acorn handles VDU 24.  (additionally setting the origin using VDU 29 would make for a double-offset)

all uses of `translateViewport` have been changed to use `translateCanvas` instead.  this should make behaviour more understandable, and more predictable, and consistent with Acorn.

besides fixing the observed VDU 24 issue, this PR changes the behaviour of two other commands so that they now both work strictly relative to the defined graphics origin, ignoring the defined graphics clipping rectangle/viewport.  those changes apply to `VDU 23,0,&89,4,x;t;` which sets the mouse cursor position, and the “get pixel” command `VDU 23,0,&84,x;y;`

fixes breakintoprogram/agon-vdp#71