### PR TITLE
Change platformio espressif32 platform to v6.3.0.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 src_dir = video
 
 [env:esp32dev]
-platform = espressif32@6.4.0
+platform = espressif32@6.3.0 ;v6.4.0 breaks video mode 3 because it uses more memory
 board = esp32dev
 board_build.flash_mode = qio
 board_build.f_cpu = 240000000L


### PR DESCRIPTION
This does fix video mode 3, which failed with v6.4.0 because of low memory. v6.3.0 uses arduino v2.0.9.