### PR TITLE
Add support to select all keyboard layouts.

### DIFF
--- a/video/agon_ps2.h
+++ b/video/agon_ps2.h
@@ -63,6 +63,15 @@ void setKeyboardLayout(uint8_t region) {
 		case 6:	kb->setLayout(&fabgl::BelgianLayout); break;
 		case 7:	kb->setLayout(&fabgl::NorwegianLayout); break;
 		case 8:	kb->setLayout(&fabgl::JapaneseLayout);break;
+    case 9: kb->setLayout(&fabgl::USInternationalLayout);break;
+    case 10: kb->setLayout(&fabgl::USInternationalAltLayout);break;
+    case 11: kb->setLayout(&fabgl::SwissGLayout);break;
+    case 12: kb->setLayout(&fabgl::SwissFLayout);break;
+    case 13: kb->setLayout(&fabgl::DanishLayout);break;
+    case 14: kb->setLayout(&fabgl::SwedishLayout);break;
+    case 15: kb->setLayout(&fabgl::PortugueseLayout);break;
+    case 16: kb->setLayout(&fabgl::BrazilianPortugueseLayout);break;
+    case 17: kb->setLayout(&fabgl::DvorakLayout);break;
 		default:
 			kb->setLayout(&fabgl::UKLayout);
 			break;


### PR DESCRIPTION
This will allow all the keyboard layouts supported within vdp-gl to be selected when running mos/vdp.