### PR TITLE
fix bitmap plot screen location

### DIFF
--- a/video/sprites.h
+++ b/video/sprites.h
@@ -43,7 +43,7 @@ inline uint16_t getCurrentBitmapId() {
 void drawBitmap(uint16_t x, uint16_t y) {
 	auto bitmap = getBitmap();
 	if (bitmap) {
-		canvas->drawBitmap(x, y, bitmap.get());
+		canvas->drawBitmap(x, logicalCoords ? y - bitmap->height : y, bitmap.get());
 	} else {
 		debug_log("drawBitmap: bitmap %d not found\n\r", currentBitmap);
 	}


### PR DESCRIPTION
the bitmap plot code was always plotting based on the top-left corner of the bitmap.  when using OS coordinates this is incorrect behaviour - plot location should be based on the bottom-left corner, as per Acorn GXR

this fixes that behaviour