### PR TITLE
add support for copy-screen-to-bitmap

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@ board_build.f_cpu = 240000000L
 board_build.f_flash = 80000000L
 framework = arduino
 lib_deps =
-    https://github.com/avalonbits/vdp-gl.git#1.0.5
+    https://github.com/AgonConsole8/vdp-gl.git#copy-to-bitmap
     fbiego/ESP32Time@^2.0.0
 build_flags =
     -DBOARD_HAS_PSRAM

--- a/video/vdu_sprites.h
+++ b/video/vdu_sprites.h
@@ -11,7 +11,7 @@
 
 // Sprite Engine, VDU command handler
 //
-void VDUStreamProcessor::vdu_sys_sprites(void) {
+void VDUStreamProcessor::vdu_sys_sprites() {
 	auto cmd = readByte_t();
 
 	switch (cmd) {
@@ -23,20 +23,37 @@ void VDUStreamProcessor::vdu_sys_sprites(void) {
 			}
 		}	break;
 
-		case 1:		// Send bitmap data
-		case 2: {	// Define bitmap in single color
+		case 1:	{	// Create new bitmap from stream (RGBA8888) or screen (Native, RGB222)
 			auto rw = readWord_t(); if (rw == -1) return;
 			auto rh = readWord_t(); if (rh == -1) return;
 
-			if (rw == 0 && rh == 0) {
-				// TODO support defining bitmap from screen area
-				// as per Acorn GXR
-				// which defines area with last two graphics move commands
-				debug_log("vdu_sys_sprites: bitmap %d - zero size\n\r", getCurrentBitmapId());
+			if (rh == 0) {
+				if (rw <= 255) {
+					// capture bitmap from screen as per GXR
+					// area defined from last two graphics move commands
+					// bitmap ID sent in first rw byte
+					createBitmapFromScreen(rw + BUFFERED_BITMAP_BASEID);
+				} else {
+					// invalid bitmap size definition for sending bitmap data stream
+					debug_log("vdu_sys_sprites: bitmap %d - zero size\n\r", getCurrentBitmapId());
+				}
 				return;
 			}
 
-			receiveBitmap(cmd, rw, rh);
+			receiveBitmap(getCurrentBitmapId(), rw, rh);
+		}	break;
+
+		case 2: {	// Define bitmap in single color
+			auto rw = readWord_t(); if (rw == -1) return;
+			auto rh = readWord_t(); if (rh == -1) return;
+			uint32_t color;
+			auto remaining = readIntoBuffer((uint8_t *)&color, sizeof(uint32_t));
+			if (remaining > 0) {
+				debug_log("vdu_sys_sprites: failed to receive color data\n\r");
+				return;
+			}
+
+			createEmptyBitmap(getCurrentBitmapId(), rw, rh, color);
 		}	break;
 
 		case 3: {	// Draw bitmap to screen (x,y)
@@ -149,8 +166,14 @@ void VDUStreamProcessor::vdu_sys_sprites(void) {
 		case 0x21: {	// Create bitmap from buffer
 			auto width = readWord_t(); if (width == -1) return;
 			auto height = readWord_t(); if (height == -1) return;
-			auto format = readByte_t(); if (format == -1) return;
-			createBitmapFromBuffer(getCurrentBitmapId(), format, width, height);
+			if (height == 0) {
+				// capture bitmap from the screen, as per GXR
+				// buffer ID sent in "width" word, format byte not required/ignored
+				createBitmapFromScreen(width);
+			} else {
+				auto format = readByte_t(); if (format == -1) return;
+				createBitmapFromBuffer(getCurrentBitmapId(), format, width, height);
+			}
 		}	break;
 
 		case 0x26: {	// add sprite frame for bitmap (long ID)
@@ -175,41 +198,63 @@ void VDUStreamProcessor::vdu_sys_sprites(void) {
 	}
 }
 
-void VDUStreamProcessor::receiveBitmap(uint8_t cmd, uint16_t width, uint16_t height) {
-	auto bufferId = getCurrentBitmapId();
-
+void VDUStreamProcessor::receiveBitmap(uint16_t bufferId, uint16_t width, uint16_t height) {
 	// clear the buffer
 	bufferClear(bufferId);
-
-	uint32_t size = sizeof(uint32_t) * width * height;
-
-	if (cmd == 1) {
-		// receive the data
-		if (bufferWrite(bufferId, size) != 0) {
-			// timed out, or couldn't allocate buffer - so abort
-			return;
-		}
-		// create RGBA8888 bitmap from buffer
-		createBitmapFromBuffer(bufferId, 0, width, height);
-	} else if (cmd == 2) {
-		uint32_t color;
-		auto remaining = readIntoBuffer((uint8_t *)&color, sizeof(uint32_t));
-		if (remaining > 0) {
-			debug_log("vdu_sys_sprites: failed to receive color data\n\r");
-			return;
-		}
-		// create a new buffer of appropriate size
-		auto buffer = bufferCreate(bufferId, size);
-		if (!buffer) {
-			debug_log("vdu_sys_sprites: failed to create buffer\n\r");
-			return;
-		}
-		auto dataptr = (uint32_t *)buffer->getBuffer();
-		for (auto n = 0; n < width*height; n++) dataptr[n] = color;
-		// create RGBA8888 bitmap from buffer
-		createBitmapFromBuffer(bufferId, 0, width, height);
+	// receive the data
+	if (bufferWrite(bufferId, sizeof(uint32_t) * width * height) != 0) {
+		// timed out, or couldn't allocate buffer - so abort
+		return;
 	}
-	return;
+	// create RGBA8888 bitmap from buffer
+	createBitmapFromBuffer(bufferId, 0, width, height);
+}
+
+void VDUStreamProcessor::createBitmapFromScreen(uint16_t bufferId) {
+	bufferClear(bufferId);
+	// get screen rectangle from last two graphics cursor positions
+	auto x1 = p1.X;
+	auto y1 = p1.Y;
+	auto x2 = p2.X;
+	auto y2 = p2.Y;
+	auto width = x2 - x1;
+	auto height = y2 - y1;
+	// normalize to positive values
+	if (width < 0) {
+		width = -width;
+		x1 = x2;
+	}
+	if (height < 0) {
+		height = -height;
+		y1 = y2;
+	}
+	auto size = width * height;
+	if (size == 0) {
+		debug_log("vdu_sys_sprites: bitmap %d - zero size\n\r", bufferId);
+		return;
+	}
+
+	// create a new buffer of appropriate size, and set as a native format bitmap
+	auto buffer = bufferCreate(bufferId, size);
+	createBitmapFromBuffer(bufferId, 3, width, height);
+	// Copy screen area to buffer
+	canvas->copyToBitmap(x1, y1, getBitmap(bufferId).get());
+}
+
+void VDUStreamProcessor::createEmptyBitmap(uint16_t bufferId, uint16_t width, uint16_t height, uint32_t color) {
+	bufferClear(bufferId);
+
+	// create a new buffer of appropriate size
+	uint32_t size = width * height;
+	auto buffer = bufferCreate(bufferId, sizeof(uint32_t) * size);
+	if (!buffer) {
+		debug_log("vdu_sys_sprites: failed to create buffer\n\r");
+		return;
+	}
+	auto dataptr = (uint32_t *)buffer->getBuffer();
+	for (auto n = 0; n < size; n++) dataptr[n] = color;
+	// create RGBA8888 bitmap from buffer
+	createBitmapFromBuffer(bufferId, 0, width, height);
 }
 
 void VDUStreamProcessor::createBitmapFromBuffer(uint16_t bufferId, uint8_t format, uint16_t width, uint16_t height) {
@@ -243,6 +288,10 @@ void VDUStreamProcessor::createBitmapFromBuffer(uint16_t bufferId, uint8_t forma
 			pixelFormat = PixelFormat::Mask;
 			bytesPerPixel = 1./8.;
 			break;
+		case 3: // Native
+			pixelFormat = PixelFormat::Native;
+			bytesPerPixel = 1.;
+			break;
 		default:
 			pixelFormat = PixelFormat::RGBA8888;
 			bytesPerPixel = 4.;
@@ -257,7 +306,7 @@ void VDUStreamProcessor::createBitmapFromBuffer(uint16_t bufferId, uint8_t forma
 		return;
 	}
 	auto data = stream->getBuffer();
-	if (bytesPerPixel < 1) {
+	if (bytesPerPixel == 2) {
 		bitmaps[bufferId] = make_shared_psram<Bitmap>(width, height, (uint8_t *)data, pixelFormat, gfg);
 	} else {
 		bitmaps[bufferId] = make_shared_psram<Bitmap>(width, height, (uint8_t *)data, pixelFormat);

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -60,8 +60,10 @@ class VDUStreamProcessor {
 		uint8_t setSampleRepeatStart(uint16_t bufferId, uint32_t offset);
 		uint8_t setSampleRepeatLength(uint16_t bufferId, uint32_t length);
 
-		void vdu_sys_sprites(void);
-		void receiveBitmap(uint8_t cmd, uint16_t width, uint16_t height);
+		void vdu_sys_sprites();
+		void receiveBitmap(uint16_t bufferId, uint16_t width, uint16_t height);
+		void createBitmapFromScreen(uint16_t bufferId);
+		void createEmptyBitmap(uint16_t bufferId, uint16_t width, uint16_t height, uint32_t color);
 		void createBitmapFromBuffer(uint16_t bufferId, uint8_t format, uint16_t width, uint16_t height);
 
 		void vdu_sys_hexload(void);

--- a/video/version.h
+++ b/video/version.h
@@ -2,10 +2,10 @@
 #define VERSION_H
 
 #define		VERSION_MAJOR		2
-#define		VERSION_MINOR		1
+#define		VERSION_MINOR		2
 #define		VERSION_PATCH		0
-#define		VERSION_CANDIDATE	0			// Optional
-#define		VERSION_TYPE		"Release"	// RC, Alpha, Beta, etc.
+#define		VERSION_CANDIDATE	1			// Optional
+#define		VERSION_TYPE		"Experimental "	// RC, Alpha, Beta, etc.
 
 #define		VERSION_VARIANT		"Console8"
 


### PR DESCRIPTION
adds support for Acorn GXR style “copy screen to bitmap” command sequence

this is supported on both `VDU 23,27,1,n,0,0,0` to define bitmap `n` from the last two graphics cursor positions, using an 8-bit bitmap ID and also `VDU 23,27,&21,n;0;` using a 16-bit bitmap/buffer ID

these commands are compatible with the existing `VDU 23,27,1` and `VDU 23,27,&21` commands - the system can tell the difference as these variants require a zero “height” value

if the buffer specified already exists then it will be deleted/cleared before the new bitmap is created from the screen.  the resultant bitmap data will be in vdp-gl’s `Bitmap::Native` format

the original Acorn command documentation specifies that a few more zeros should be sent.  you can safely send additional zeros, as per Acorn’s documentation, as they will just be ignored.

it should be noted that `VDU 23,27,&21` when pointing to an existing buffer to set it to be a bitmap also usually expects a `format` byte, but this isn’t required/supported/needed for copying screen to bitmap, i.e. this command variant requires one less byte to be sent

requires an updated/custom vdp-gl