### PR TITLE
add ability to exit terminal mode

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -241,6 +241,18 @@
 //
 void debug_log(const char *format, ...);
 
+// Terminal states
+//
+enum TerminalState {
+	Disabled,
+	Disabling,
+	Enabling,
+	Enabled,
+	Suspending,
+	Suspended,
+	Resuming
+};
+
 // Additional modelines
 //
 #ifndef VGA_640x240_60Hz

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -15,7 +15,7 @@
 #include "vdu_sprites.h"
 #include "updater.h"
 
-extern void switchTerminalMode(bool enable);	// Switch to terminal mode
+extern void startTerminal();					// Start the terminal
 extern void setConsoleMode(bool mode);			// Set console mode
 
 bool			initialised = false;			// Is the system initialised yet?
@@ -173,7 +173,7 @@ void VDUStreamProcessor::vdu_sys_video() {
 			setConsoleMode((bool) b);
 		}	break;
 		case VDP_TERMINALMODE: {		// VDU 23, 0, &FF
-			switchTerminalMode(true); 	// Switch to terminal mode
+			startTerminal();		 	// Switch to, or resume, terminal mode
 		}	break;
   	}
 }

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -15,7 +15,7 @@
 #include "vdu_sprites.h"
 #include "updater.h"
 
-extern void switchTerminalMode();				// Switch to terminal mode
+extern void switchTerminalMode(bool enable);	// Switch to terminal mode
 extern void setConsoleMode(bool mode);			// Set console mode
 
 bool			initialised = false;			// Is the system initialised yet?
@@ -173,7 +173,7 @@ void VDUStreamProcessor::vdu_sys_video() {
 			setConsoleMode((bool) b);
 		}	break;
 		case VDP_TERMINALMODE: {		// VDU 23, 0, &FF
-			switchTerminalMode(); 		// Switch to terminal mode
+			switchTerminalMode(true); 	// Switch to terminal mode
 		}	break;
   	}
 }

--- a/video/video.ino
+++ b/video/video.ino
@@ -55,6 +55,7 @@
 HardwareSerial	DBGSerial(0);
 
 bool			terminalMode = false;			// Terminal mode (for CP/M)
+bool			exitTerminal = false;			// Flag to indicate terminal mode should be exited
 bool			consoleMode = false;			// Serial console mode (0 = off, 1 = console enabled)
 
 #include "agon.h"								// Configuration file
@@ -68,7 +69,7 @@ bool			consoleMode = false;			// Serial console mode (0 = off, 1 = console enabl
 #include "vdu_stream_processor.h"
 #include "hexload.h"
 
-fabgl::Terminal			Terminal;				// Used for CP/M mode
+std::unique_ptr<fabgl::Terminal>	Terminal;	// Used for CP/M mode
 VDUStreamProcessor *	processor;				// VDU Stream Processor
 
 #include "zdi.h"								// ZDI debugging console
@@ -96,6 +97,10 @@ void loop() {
 
 	while (true) {
 		if (terminalMode) {
+			if (exitTerminal) {
+				switchTerminalMode(false);
+				continue;
+			}
 			do_keyboard_terminal();
 			continue;
 		}
@@ -158,7 +163,7 @@ void do_keyboard_terminal() {
 	// Write anything read from z80 to the screen
 	//
 	while (processor->byteAvailable()) {
-		Terminal.write(processor->readByte());
+		Terminal->write(processor->readByte());
 	}
 }
 
@@ -218,13 +223,43 @@ void setConsoleMode(bool mode) {
 
 // Switch to terminal mode
 //
-void switchTerminalMode() {
+void switchTerminalMode(bool enable) {
+	if (terminalMode == enable) {
+		return;
+	}
+	exitTerminal = false;
 	cls(true);
 	canvas.reset();
-	Terminal.begin(_VGAController.get());	
-	Terminal.connectSerialPort(VDPSerial);
-	Terminal.enableCursor(true);
-	terminalMode = true;
+	if (enable) {
+		Terminal = std::unique_ptr<fabgl::Terminal>(new fabgl::Terminal());
+		Terminal->begin(_VGAController.get());	
+		Terminal->connectSerialPort(VDPSerial);
+		Terminal->enableCursor(true);
+		// onVirtualKey is triggered whenever a key is pressed or released
+		Terminal->onVirtualKeyItem = [&](VirtualKeyItem * vkItem) {
+			if (vkItem->vk == VirtualKey::VK_F12) {
+				if (vkItem->CTRL && (vkItem->LALT || vkItem->RALT)) {
+					// CTRL + ALT + F12: emergency exit terminal mode
+					exitTerminal = true;
+				}
+			}
+		};
+
+		// onUserSequence is triggered whenever a User Sequence has been received (ESC + '_#' ... '$'), where '...' is sent here
+		Terminal->onUserSequence = [&](char const * seq) {
+			// 'Q!': exit terminal mode
+			if (strcmp("Q!", seq) == 0) {
+				exitTerminal = true;
+			}
+		};
+	} else {
+		Terminal->deactivate();
+		Terminal = nullptr;
+		set_mode(1);
+		processor->sendModeInformation();
+	}
+	terminalMode = enable;
+	debug_log("Terminal mode %s\n\r", terminalMode ? "enabled" : "disabled");
 }
 
 void print(char const * text) {

--- a/video/video.ino
+++ b/video/video.ino
@@ -54,11 +54,11 @@
 
 HardwareSerial	DBGSerial(0);
 
-bool			terminalMode = false;			// Terminal mode (for CP/M)
-bool			exitTerminal = false;			// Flag to indicate terminal mode should be exited
+#include "agon.h"								// Configuration file
+
+TerminalState	terminalState = TerminalState::Disabled;		// Terminal state (for CP/M, etc)
 bool			consoleMode = false;			// Serial console mode (0 = off, 1 = console enabled)
 
-#include "agon.h"								// Configuration file
 #include "version.h"							// Version information
 #include "agon_ps2.h"							// Keyboard support
 #include "agon_audio.h"							// Audio support
@@ -96,12 +96,7 @@ void loop() {
 	auto cursorTime = millis();
 
 	while (true) {
-		if (terminalMode) {
-			if (exitTerminal) {
-				switchTerminalMode(false);
-				continue;
-			}
-			do_keyboard_terminal();
+		if (processTerminal()) {
 			continue;
 		}
 		if (millis() - cursorTime > CURSOR_PHASE) {
@@ -159,12 +154,6 @@ void do_keyboard_terminal() {
 		// send raw byte straight to z80
 		processor->writeByte(ascii);
 	}
-
-	// Write anything read from z80 to the screen
-	//
-	while (processor->byteAvailable()) {
-		Terminal->write(processor->readByte());
-	}
 }
 
 // Handle the mouse
@@ -221,45 +210,126 @@ void setConsoleMode(bool mode) {
 	consoleMode = mode;
 }
 
-// Switch to terminal mode
+// Terminal mode state machine transition calls
 //
-void switchTerminalMode(bool enable) {
-	if (terminalMode == enable) {
-		return;
+void startTerminal() {
+	switch (terminalState) {
+		case TerminalState::Disabled: {
+			terminalState = TerminalState::Enabling;
+		} break;
+		case TerminalState::Suspending: {
+			terminalState = TerminalState::Enabled;
+		} break;
+		case TerminalState::Suspended: {
+			terminalState = TerminalState::Resuming;
+		} break;
 	}
-	exitTerminal = false;
-	cls(true);
-	canvas.reset();
-	if (enable) {
-		Terminal = std::unique_ptr<fabgl::Terminal>(new fabgl::Terminal());
-		Terminal->begin(_VGAController.get());	
-		Terminal->connectSerialPort(VDPSerial);
-		Terminal->enableCursor(true);
-		// onVirtualKey is triggered whenever a key is pressed or released
-		Terminal->onVirtualKeyItem = [&](VirtualKeyItem * vkItem) {
-			if (vkItem->vk == VirtualKey::VK_F12) {
-				if (vkItem->CTRL && (vkItem->LALT || vkItem->RALT)) {
-					// CTRL + ALT + F12: emergency exit terminal mode
-					exitTerminal = true;
-				}
-			}
-		};
+}
 
-		// onUserSequence is triggered whenever a User Sequence has been received (ESC + '_#' ... '$'), where '...' is sent here
-		Terminal->onUserSequence = [&](char const * seq) {
-			// 'Q!': exit terminal mode
-			if (strcmp("Q!", seq) == 0) {
-				exitTerminal = true;
-			}
-		};
-	} else {
-		Terminal->deactivate();
-		Terminal = nullptr;
-		set_mode(1);
-		processor->sendModeInformation();
+void stopTerminal() {
+	switch (terminalState) {
+		case TerminalState::Enabled:
+		case TerminalState::Resuming: 
+		case TerminalState::Suspended:
+		case TerminalState::Suspending: {
+			terminalState = TerminalState::Disabling;
+		} break;
+		case TerminalState::Enabling: {
+			terminalState = TerminalState::Disabled;
+		} break;
 	}
-	terminalMode = enable;
-	debug_log("Terminal mode %s\n\r", terminalMode ? "enabled" : "disabled");
+}
+
+void suspendTerminal() {
+	switch (terminalState) {
+		case TerminalState::Enabled:
+		case TerminalState::Resuming: {
+			terminalState = TerminalState::Suspending;
+			processTerminal();
+		} break;
+		case TerminalState::Enabling: {
+			// Finish enabling, then suspend
+			processTerminal();
+			terminalState = TerminalState::Suspending;
+		} break;
+	}
+}
+
+// Process terminal state machine
+//
+bool processTerminal() {
+	switch (terminalState) {
+		case TerminalState::Disabled: {
+			// Terminal is not currently active, so pass on to VDU system
+			return false;
+		} break;
+		case TerminalState::Suspended: {
+			// Terminal temporarily deactivated, so pass on to VDU system
+			// but keep processing keyboard input
+			do_keyboard_terminal();
+			return false;
+		} break;
+		case TerminalState::Enabling: {
+			// Turn on the terminal
+			Terminal = std::unique_ptr<fabgl::Terminal>(new fabgl::Terminal());
+			Terminal->begin(_VGAController.get());	
+			Terminal->connectSerialPort(VDPSerial);
+			Terminal->enableCursor(true);
+			// onVirtualKey is triggered whenever a key is pressed or released
+			Terminal->onVirtualKeyItem = [&](VirtualKeyItem * vkItem) {
+				if (vkItem->vk == VirtualKey::VK_F12) {
+					if (vkItem->CTRL && (vkItem->LALT || vkItem->RALT)) {
+						// CTRL + ALT + F12: emergency exit terminal mode
+						stopTerminal();
+					}
+				}
+			};
+
+			// onUserSequence is triggered whenever a User Sequence has been received (ESC + '_#' ... '$'), where '...' is sent here
+			Terminal->onUserSequence = [&](char const * seq) {
+				// 'Q!': exit terminal mode
+				if (strcmp("Q!", seq) == 0) {
+					stopTerminal();
+				}
+				if (strcmp("S!", seq) == 0) {
+					suspendTerminal();
+				}
+			};
+			debug_log("Terminal enabled\n\r");
+			terminalState = TerminalState::Enabled;
+		} break;
+		case TerminalState::Enabled: {
+			do_keyboard_terminal();
+			// Write anything read from z80 to the screen
+			// but do this a byte at a time, as VDU commands after a "suspend" will get lost
+			if (processor->byteAvailable()) {
+				Terminal->write(processor->readByte());
+			}
+		} break;
+		case TerminalState::Disabling: {
+			Terminal->deactivate();
+			Terminal = nullptr;
+			set_mode(1);
+			processor->sendModeInformation();
+			debug_log("Terminal disabled\n\r");
+			terminalState = TerminalState::Disabled;
+		} break;
+		case TerminalState::Suspending: {
+			// No need to deactivate terminal here... we just stop sending it serial data
+			debug_log("Terminal suspended\n\r");
+			terminalState = TerminalState::Suspended;
+		} break;
+		case TerminalState::Resuming: {
+			// As we're not deactivating the terminal, we don't need to re-activate it here
+			debug_log("Terminal resumed\n\r");
+			terminalState = TerminalState::Enabled;
+		} break;
+		default: {
+			debug_log("processTerminal: unknown terminal state %d\n\r", terminalState);
+			return false;
+		} break;
+	}
+	return true;
 }
 
 void print(char const * text) {


### PR DESCRIPTION
terminal mode can be exited by sending a “user sequence” of characters, `ESC + ‘_#Q!$’` additionally an “emergency escape” key combo of ctrl+alt+f12 is supported