### PR TITLE
Re-fix mono bitmap creation

### DIFF
--- a/video/vdu_sprites.h
+++ b/video/vdu_sprites.h
@@ -306,7 +306,7 @@ void VDUStreamProcessor::createBitmapFromBuffer(uint16_t bufferId, uint8_t forma
 		return;
 	}
 	auto data = stream->getBuffer();
-	if (bytesPerPixel == 2) {
+	if (bytesPerPixel < 1) {
 		bitmaps[bufferId] = make_shared_psram<Bitmap>(width, height, (uint8_t *)data, pixelFormat, gfg);
 	} else {
 		bitmaps[bufferId] = make_shared_psram<Bitmap>(width, height, (uint8_t *)data, pixelFormat);

--- a/video/version.h
+++ b/video/version.h
@@ -3,7 +3,7 @@
 
 #define		VERSION_MAJOR		2
 #define		VERSION_MINOR		2
-#define		VERSION_PATCH		0
+#define		VERSION_PATCH		1
 #define		VERSION_CANDIDATE	0			// Optional
 #define		VERSION_TYPE		"Release"	// RC, Alpha, Beta, etc.
 


### PR DESCRIPTION
Somehow code to create bitmaps from an area of screen introduced a bug that would prevent mono bitmaps from working.  this fixes that issue

also bumps version number for new release with this fix