### PR TITLE
fix duration calculation

### DIFF
--- a/video/audio_sample.h
+++ b/video/audio_sample.h
@@ -16,7 +16,6 @@ struct AudioSample {
 	int8_t getSample(uint32_t & index, uint32_t & blockIndex);
 	void seekTo(uint32_t position, uint32_t & index, uint32_t & blockIndex, int32_t & repeatCount);
 	uint32_t getSize();
-	uint32_t getDuration();
 
 	std::vector<std::shared_ptr<BufferStream>>& blocks;
 	uint8_t			format;				// Format of the sample data
@@ -92,11 +91,6 @@ uint32_t AudioSample::getSize() {
 		samples += block->size();
 	}
 	return samples;
-}
-
-uint32_t AudioSample::getDuration() {
-	// returns duration of sample in ms when played back without tuning
-	return (getSize() * 1000) / sampleRate;
 }
 
 #endif // AUDIO_SAMPLE_H

--- a/video/enhanced_samples_generator.h
+++ b/video/enhanced_samples_generator.h
@@ -83,7 +83,10 @@ int EnhancedSamplesGenerator::getSample() {
 }
 
 int EnhancedSamplesGenerator::getDuration(uint16_t frequency) {
-	return _sample.expired() ? 0 : _sample.lock()->getDuration() / calculateSamplerate(frequency);
+	// TODO this will produce an incorrect duration if the sample rate for the channel has been
+	// adjusted to differ from the underlying audio system sample rate
+	// At this point it's not clear how to resolve this, so we'll assume it hasn't been adjusted
+	return _sample.expired() ? 0 : (_sample.lock()->getSize() * 1000 / sampleRate()) / calculateSamplerate(frequency);
 }
 
 void EnhancedSamplesGenerator::seekTo(uint32_t position) {


### PR DESCRIPTION
duration of a sample when played back calculation was buggy, resulting in looping samples when they shouldn’t

the sample generator’s `getDuration` call needs to calculate based on how long the _underlying_ audio system will take to step through samples, therefore it is the sample rate of the underlying system that needs to be used for calculations