### PR TITLE
bitmap fixes

### DIFF
--- a/video/graphics.h
+++ b/video/graphics.h
@@ -479,7 +479,7 @@ void plotCopyMove(uint8_t mode) {
 // Plot bitmap
 //
 void plotBitmap() {
-	drawBitmap(p1.X, p1.Y);
+	drawBitmap(p1.X, p1.Y, true);
 }
 
 // Character plot

--- a/video/sprites.h
+++ b/video/sprites.h
@@ -40,10 +40,10 @@ inline uint16_t getCurrentBitmapId() {
 	return currentBitmap;
 }
 
-void drawBitmap(uint16_t x, uint16_t y) {
+void drawBitmap(uint16_t x, uint16_t y, bool compensateHeight = false) {
 	auto bitmap = getBitmap();
 	if (bitmap) {
-		canvas->drawBitmap(x, logicalCoords ? y - bitmap->height : y, bitmap.get());
+		canvas->drawBitmap(x, (compensateHeight && logicalCoords) ? y - bitmap->height : y, bitmap.get());
 	} else {
 		debug_log("drawBitmap: bitmap %d not found\n\r", currentBitmap);
 	}

--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -263,7 +263,7 @@ void VDUStreamProcessor::bufferClear(uint16_t bufferId) {
 // This is used for creating buffers to redirect output to
 //
 std::shared_ptr<WritableBufferStream> VDUStreamProcessor::bufferCreate(uint16_t bufferId, uint32_t size) {
-	if (bufferId == 0 || bufferId == 65535) {
+	if (bufferId == 65535) {
 		debug_log("bufferCreate: bufferId %d is reserved\n\r", bufferId);
 		return nullptr;
 	}

--- a/video/vdu_sprites.h
+++ b/video/vdu_sprites.h
@@ -236,6 +236,10 @@ void VDUStreamProcessor::createBitmapFromScreen(uint16_t bufferId) {
 
 	// create a new buffer of appropriate size, and set as a native format bitmap
 	auto buffer = bufferCreate(bufferId, size);
+	if (!buffer) {
+		debug_log("vdu_sys_sprites: failed to create buffer\n\r");
+		return;
+	}
 	createBitmapFromBuffer(bufferId, 3, width, height);
 	// Copy screen area to buffer
 	canvas->copyToBitmap(x1, y1, getBitmap(bufferId).get());


### PR DESCRIPTION
fixes issue with capturing bitmap to buffer zero
(the `createBuffer` call was preventing creation of buffer with ID 0, as it can’t be used as a place to redirect output)

fixes recently introduced bug with behaviour of VDU 23,27,3 caused by changes to drawBitmap which was compensating for the height of the bitmap when it should only do that for plot calls