### PR TITLE
valueSize in reverseValues function changed from 8 bits to 16 bits

### DIFF
--- a/video/buffers.h
+++ b/video/buffers.h
@@ -25,7 +25,7 @@ int32_t resolveBufferId(int32_t bufferId, uint16_t currentId) {
 }
 
 // Reverse values in a buffer
-void reverseValues(uint8_t * data, uint32_t length, uint8_t valueSize) {
+void reverseValues(uint8_t * data, uint32_t length, uint16_t valueSize) {
 	// get last offset into buffer
 	auto bufferEnd = length - valueSize;
 


### PR DESCRIPTION
VDUStreamProcessor::bufferReverse passes in a word when it calls this function, so valueSize should be 16 bits.  This will enable vertical flipping of bitmaps wider than 255 pixels.