### PR TITLE
Further audio system enhancements

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -126,6 +126,7 @@
 
 #define AUDIO_ENVELOPE_NONE		0		// No envelope
 #define AUDIO_ENVELOPE_ADSR		1		// Simple ADSR volume envelope
+#define AUDIO_ENVELOPE_MULTIPHASE_ADSR		2		// Multi-phase ADSR envelope
 
 #define AUDIO_FREQUENCY_ENVELOPE_STEPPED	1		// Stepped frequency envelope
 

--- a/video/agon.h
+++ b/video/agon.h
@@ -94,6 +94,7 @@
 #define AUDIO_CMD_SEEK			11		// Seek to a position in a sample
 #define AUDIO_CMD_DURATION		12		// Set the duration of a channel
 #define AUDIO_CMD_SAMPLERATE	13		// Set the samplerate for channel or underlying audio system
+#define AUDIO_CMD_SET_PARAM		14		// Set a waveform parameter
 
 #define AUDIO_WAVE_DEFAULT		0		// Default waveform (Square wave)
 #define AUDIO_WAVE_SQUARE		0		// Square wave
@@ -133,6 +134,12 @@
 #define AUDIO_FREQUENCY_REPEATS 0x01	// Repeat/loop the frequency envelope
 #define AUDIO_FREQUENCY_CUMULATIVE	0x02	// Reset frequency envelope when looping
 #define AUDIO_FREQUENCY_RESTRICT	0x04	// Restrict frequency envelope to the range 0-65535
+
+#define AUDIO_PARAM_DUTY_CYCLE		0		// Square wave duty cycle
+#define AUDIO_PARAM_VOLUME			2		// Volume
+#define AUDIO_PARAM_FREQUENCY		3		// Frequency
+#define AUDIO_PARAM_16BIT			0x80	// 16-bit value
+#define AUDIO_PARAM_MASK			0x0F	// Parameter mask
 
 #define AUDIO_STATUS_ACTIVE		0x01	// Has an active waveform
 #define AUDIO_STATUS_PLAYING	0x02	// Playing a note (not in release phase)

--- a/video/agon_audio.h
+++ b/video/agon_audio.h
@@ -129,27 +129,87 @@ uint8_t getChannelStatus(uint8_t channel) {
 
 // Set channel volume
 //
-void setVolume(uint8_t channel, uint8_t volume) {
+uint8_t setVolume(uint8_t channel, uint8_t volume) {
 	if (channelEnabled(channel)) {
-		audioChannels[channel]->setVolume(volume);
+		return audioChannels[channel]->setVolume(volume);
 	}
+	return 1;
 }
 
 // Set channel frequency
 //
-void setFrequency(uint8_t channel, uint16_t frequency) {
+uint8_t setFrequency(uint8_t channel, uint16_t frequency) {
 	if (channelEnabled(channel)) {
-		audioChannels[channel]->setFrequency(frequency);
+		return audioChannels[channel]->setFrequency(frequency);
 	}
+	return 1;
 }
 
 // Set channel waveform
 //
-void setWaveform(uint8_t channel, int8_t waveformType, uint16_t sampleId) {
+uint8_t setWaveform(uint8_t channel, int8_t waveformType, uint16_t sampleId) {
 	if (channelEnabled(channel)) {
 		auto channelRef = audioChannels[channel];
-		channelRef->setWaveform(waveformType, channelRef, sampleId);
+		return channelRef->setWaveform(waveformType, channelRef, sampleId);
 	}
+	return 1;
+}
+
+// Seek to a position on a channel
+//
+uint8_t seekTo(uint8_t channel, uint32_t position) {
+	if (channelEnabled(channel)) {
+		return audioChannels[channel]->seekTo(position);
+	}
+	return 1;
+}
+
+// Set channel duration
+//
+uint8_t setDuration(uint8_t channel, uint16_t duration) {
+	if (channelEnabled(channel)) {
+		return audioChannels[channel]->setDuration(duration);
+	}
+	return 1;
+}
+
+// Set channel sample rate
+//
+uint8_t setSampleRate(uint8_t channel, uint16_t sampleRate) {
+	if (channel == 255) {
+		// set underlying sample rate
+		setSampleRate(sampleRate);
+		return 0;
+	}
+	if (channelEnabled(channel)) {
+		return audioChannels[channel]->setSampleRate(sampleRate);
+	}
+	return 1;
+}
+
+// Enable a channel
+//
+uint8_t enableChannel(uint8_t channel) {
+	if (channelEnabled(channel)) {
+		// channel already enabled
+		return 0;
+	}
+	if (channel >= 0 && channel < MAX_AUDIO_CHANNELS && audioChannels[channel] == nullptr) {
+		// channel not enabled, so enable it
+		initAudioChannel(channel);
+		return 0;
+	}
+	return 1;
+}
+
+// Disable a channel
+//
+uint8_t disableChannel(uint8_t channel) {
+	if (channelEnabled(channel)) {
+		audioTaskKill(channel);
+		return 0;
+	}
+	return 1;
 }
 
 // Clear a sample

--- a/video/agon_audio.h
+++ b/video/agon_audio.h
@@ -130,10 +130,16 @@ uint8_t getChannelStatus(uint8_t channel) {
 // Set channel volume
 //
 uint8_t setVolume(uint8_t channel, uint8_t volume) {
-	if (channelEnabled(channel)) {
+	if (channel == 255) {
+		if (volume == 255) {
+			return soundGenerator->volume();
+		}
+		soundGenerator->setVolume(volume < 128 ? volume : 127);
+		return soundGenerator->volume();
+	} else if (channelEnabled(channel)) {
 		return audioChannels[channel]->setVolume(volume);
 	}
-	return 1;
+	return 255;
 }
 
 // Set channel frequency
@@ -142,7 +148,7 @@ uint8_t setFrequency(uint8_t channel, uint16_t frequency) {
 	if (channelEnabled(channel)) {
 		return audioChannels[channel]->setFrequency(frequency);
 	}
-	return 1;
+	return 0;
 }
 
 // Set channel waveform
@@ -152,7 +158,7 @@ uint8_t setWaveform(uint8_t channel, int8_t waveformType, uint16_t sampleId) {
 		auto channelRef = audioChannels[channel];
 		return channelRef->setWaveform(waveformType, channelRef, sampleId);
 	}
-	return 1;
+	return 0;
 }
 
 // Seek to a position on a channel
@@ -161,7 +167,7 @@ uint8_t seekTo(uint8_t channel, uint32_t position) {
 	if (channelEnabled(channel)) {
 		return audioChannels[channel]->seekTo(position);
 	}
-	return 1;
+	return 0;
 }
 
 // Set channel duration
@@ -170,7 +176,7 @@ uint8_t setDuration(uint8_t channel, uint16_t duration) {
 	if (channelEnabled(channel)) {
 		return audioChannels[channel]->setDuration(duration);
 	}
-	return 1;
+	return 0;
 }
 
 // Set channel sample rate
@@ -184,7 +190,7 @@ uint8_t setSampleRate(uint8_t channel, uint16_t sampleRate) {
 	if (channelEnabled(channel)) {
 		return audioChannels[channel]->setSampleRate(sampleRate);
 	}
-	return 1;
+	return 0;
 }
 
 // Enable a channel
@@ -192,14 +198,14 @@ uint8_t setSampleRate(uint8_t channel, uint16_t sampleRate) {
 uint8_t enableChannel(uint8_t channel) {
 	if (channelEnabled(channel)) {
 		// channel already enabled
-		return 0;
+		return 1;
 	}
 	if (channel >= 0 && channel < MAX_AUDIO_CHANNELS && audioChannels[channel] == nullptr) {
 		// channel not enabled, so enable it
 		initAudioChannel(channel);
-		return 0;
+		return 1;
 	}
-	return 1;
+	return 0;
 }
 
 // Disable a channel
@@ -207,9 +213,9 @@ uint8_t enableChannel(uint8_t channel) {
 uint8_t disableChannel(uint8_t channel) {
 	if (channelEnabled(channel)) {
 		audioTaskKill(channel);
-		return 0;
+		return 1;
 	}
-	return 1;
+	return 0;
 }
 
 // Clear a sample
@@ -218,11 +224,11 @@ uint8_t clearSample(uint16_t sampleId) {
 	debug_log("clearSample: sample %d\n\r", sampleId);
 	if (samples.find(sampleId) == samples.end()) {
 		debug_log("clearSample: sample %d not found\n\r", sampleId);
-		return 0;
+		return 1;
 	}
 	samples[sampleId] = nullptr;
 	debug_log("reset sample\n\r");
-	return 1;
+	return 0;
 }
 
 // Reset samples

--- a/video/audio_channel.h
+++ b/video/audio_channel.h
@@ -15,7 +15,7 @@ extern void audioTaskAbortDelay(uint8_t channel);
 
 // The audio channel class
 //
-class AudioChannel {	
+class AudioChannel {
 	public:
 		AudioChannel(uint8_t channel);
 		~AudioChannel();
@@ -426,7 +426,7 @@ void AudioChannel::loop() {
 			this->seekTo(0);
 			this->_waveform->setFrequency(this->getFrequency(0));
 			this->_waveform->enable(true);
-			// if we have an envelope then we loop, otherwise just delay for duration			
+			// if we have an envelope then we loop, otherwise just delay for duration
 			if (this->_volumeEnvelope || this->_frequencyEnvelope) {
 				this->_state = AudioState::PlayLoop;
 			} else {

--- a/video/audio_channel.h
+++ b/video/audio_channel.h
@@ -8,8 +8,7 @@
 
 #include "agon.h"
 #include "types.h"
-#include "envelopes/volume.h"
-#include "envelopes/frequency.h"
+#include "envelopes/types.h"
 
 extern std::unique_ptr<fabgl::SoundGenerator> soundGenerator;	// audio handling sub-system
 extern void audioTaskAbortDelay(uint8_t channel);

--- a/video/audio_channel.h
+++ b/video/audio_channel.h
@@ -66,7 +66,7 @@ AudioChannel::AudioChannel(uint8_t channel) : _channel(channel), _state(AudioSta
 
 AudioChannel::~AudioChannel() {
 	debug_log("AudioChannel: deiniting %d\n\r", channel());
-	if (this->_waveform) {
+	if (this->_waveform != nullptr) {
 		this->_waveform->enable(false);
 		soundGenerator->detach(getWaveform());
 	}
@@ -210,7 +210,7 @@ uint8_t AudioChannel::setWaveform(int8_t waveformType, std::shared_ptr<AudioChan
 			audioTaskAbortDelay(this->_channel);
 			waitForAbort();
 		}
-		if (this->_waveform) {
+		if (this->_waveform != nullptr) {
 			debug_log("AudioChannel: detaching old waveform\n\r");
 			detachSoundGenerator();
 		}

--- a/video/audio_channel.h
+++ b/video/audio_channel.h
@@ -28,6 +28,8 @@ class AudioChannel {
 		uint8_t		setVolumeEnvelope(std::unique_ptr<VolumeEnvelope> envelope);
 		uint8_t		setFrequencyEnvelope(std::unique_ptr<FrequencyEnvelope> envelope);
 		uint8_t		setSampleRate(uint16_t sampleRate);
+		uint8_t		setDutyCycle(uint8_t dutyCycle);
+		uint8_t		setParameter(uint8_t parameter, uint16_t value);
 		WaveformGenerator * getWaveform() { return this->_waveform.get(); }
 		void		attachSoundGenerator();
 		void		detachSoundGenerator();
@@ -348,6 +350,36 @@ uint8_t AudioChannel::setSampleRate(uint16_t sampleRate) {
 	if (this->_waveform) {
 		this->_waveform->setSampleRate(sampleRate);
 		return 1;
+	}
+	return 0;
+}
+
+uint8_t AudioChannel::setDutyCycle(uint8_t dutyCycle) {
+	if (this->_waveform && this->_waveformType == AUDIO_WAVE_SQUARE) {
+		((SquareWaveformGenerator *)getWaveform())->setDutyCycle(dutyCycle);
+		return 1;
+	}
+	return 0;
+}
+
+uint8_t AudioChannel::setParameter(uint8_t parameter, uint16_t value) {
+	if (this->_waveform) {
+		bool use16Bit = parameter & AUDIO_PARAM_16BIT;
+		auto param = parameter & AUDIO_PARAM_MASK;
+		switch (param) {
+			case AUDIO_PARAM_DUTY_CYCLE: {
+				return setDutyCycle(value);
+			}	break;
+			case AUDIO_PARAM_VOLUME: {
+				return setVolume(value);
+			}	break;
+			case AUDIO_PARAM_FREQUENCY: {
+				if (!use16Bit) {
+					value = _frequency & 0xFF00 | value & 0x00FF;
+				}
+				return setFrequency(value);
+			}	break;
+		}
 	}
 	return 0;
 }

--- a/video/audio_channel.h
+++ b/video/audio_channel.h
@@ -225,6 +225,12 @@ uint8_t AudioChannel::setWaveform(int8_t waveformType, std::shared_ptr<AudioChan
 
 uint8_t AudioChannel::setVolume(uint8_t volume) {
 	debug_log("AudioChannel: setVolume %d on channel %d\n\r", volume, channel());
+	if (volume == 255) {
+		return this->_volume;
+	}
+	if (volume > 127) {
+		volume = 127;
+	}
 
 	if (this->_waveform) {
 		waitForAbort();
@@ -267,9 +273,9 @@ uint8_t AudioChannel::setVolume(uint8_t volume) {
 				}
 				break;
 		}
-		return 1;
+		return this->_volume;
 	}
-	return 0;
+	return 255;
 }
 
 uint8_t AudioChannel::setFrequency(uint16_t frequency) {

--- a/video/audio_channel.h
+++ b/video/audio_channel.h
@@ -156,6 +156,7 @@ std::shared_ptr<WaveformGenerator> AudioChannel::getSampleWaveform(uint16_t samp
 
 		return std::make_shared<EnhancedSamplesGenerator>(sample);
 	}
+	debug_log("sample %d not found\n\r", sampleId);
 	return nullptr;
 }
 
@@ -200,7 +201,7 @@ uint8_t AudioChannel::setWaveform(int8_t waveformType, std::shared_ptr<AudioChan
 			break;
 	}
 
-	if (newWaveform) {
+	if (newWaveform != nullptr) {
 		debug_log("AudioChannel: setWaveform %d on channel %d\n\r", waveformType, channel());
 		if (this->_state != AudioState::Idle) {
 			debug_log("AudioChannel: aborting current playback\n\r");

--- a/video/audio_channel.h
+++ b/video/audio_channel.h
@@ -146,7 +146,7 @@ std::shared_ptr<WaveformGenerator> AudioChannel::getSampleWaveform(uint16_t samp
 
 		// TODO remove channel tracking??
 		// remove this channel from other samples
-		// for (auto samplePair : samples) {
+		// for (auto &samplePair : samples) {
 		// 	if (samplePair.second) {
 		// 		samplePair.second->channels.erase(_channel);
 		// 	}

--- a/video/audio_sample.h
+++ b/video/audio_sample.h
@@ -28,7 +28,7 @@ struct AudioSample {
 
 AudioSample::~AudioSample() {
 	// iterate over channels
-	// for (auto channelPair : this->channels) {
+	// for (auto &channelPair : this->channels) {
 	// 	auto channel = channelPair.second.lock();
 	// 	if (channel) {
 	// 		// Remove sample from channel

--- a/video/enhanced_samples_generator.h
+++ b/video/enhanced_samples_generator.h
@@ -104,7 +104,7 @@ double EnhancedSamplesGenerator::calculateSamplerate(uint16_t frequency) {
 
 int8_t EnhancedSamplesGenerator::getNextSample() {
 	auto sample = _sample->getSample(index, blockIndex);
-	
+
 	// looping magic
 	repeatCount--;
 	if (repeatCount == 0) {

--- a/video/envelopes/adsr.h
+++ b/video/envelopes/adsr.h
@@ -1,19 +1,13 @@
 //
-// Title:			Audio Volume Envelope support
+// Title:			Audio ADSR Volume Envelope support
 // Author:			Steve Sims
 // Created:			06/08/2023
-// Last Updated:	13/08/2023
+// Last Updated:	14/01/2024
 
-#ifndef ENVELOPE_VOLUME_H
-#define ENVELOPE_VOLUME_H
+#ifndef ENVELOPE_ADSR_H
+#define ENVELOPE_ADSR_H
 
-class VolumeEnvelope {
-	public:
-		virtual uint8_t getVolume(uint8_t baseVolume, uint32_t elapsed, int32_t duration) = 0;
-		virtual bool isReleasing(uint32_t elapsed, int32_t duration) = 0;
-		virtual bool isFinished(uint32_t elapsed, int32_t duration) = 0;
-		virtual uint16_t getRelease() = 0;
-};
+#include "./types.h"
 
 class ADSRVolumeEnvelope : public VolumeEnvelope {
 	public:
@@ -21,7 +15,7 @@ class ADSRVolumeEnvelope : public VolumeEnvelope {
 		uint8_t getVolume(uint8_t baseVolume, uint32_t elapsed, int32_t duration);
 		bool isReleasing(uint32_t elapsed, int32_t duration);
 		bool isFinished(uint32_t elapsed, int32_t duration);
-		uint16_t getRelease() {
+		uint32_t getRelease() {
 			return this->_release;
 		}
 	private:
@@ -83,4 +77,4 @@ bool ADSRVolumeEnvelope::isFinished(uint32_t elapsed, int32_t duration) {
 	return (elapsed >= duration + this->_release);
 }
 
-#endif // ENVELOPE_VOLUME_H
+#endif // ENVELOPE_ADSR_H

--- a/video/envelopes/frequency.h
+++ b/video/envelopes/frequency.h
@@ -1,7 +1,7 @@
 //
-// Title:	        Audio Frequency Envelope support
-// Author:        	Steve Sims
-// Created:       	13/08/2023
+// Title:			Audio Frequency Envelope support
+// Author:			Steve Sims
+// Created:			13/08/2023
 // Last Updated:	14/01/2024
 
 #ifndef ENVELOPE_FREQUENCY_H

--- a/video/envelopes/frequency.h
+++ b/video/envelopes/frequency.h
@@ -2,7 +2,7 @@
 // Title:	        Audio Frequency Envelope support
 // Author:        	Steve Sims
 // Created:       	13/08/2023
-// Last Updated:	13/08/2023
+// Last Updated:	14/01/2024
 
 #ifndef ENVELOPE_FREQUENCY_H
 #define ENVELOPE_FREQUENCY_H
@@ -10,11 +10,7 @@
 #include <memory>
 #include <vector>
 
-class FrequencyEnvelope {
-	public:
-		virtual uint16_t getFrequency(uint16_t baseFrequency, uint32_t elapsed, int32_t duration) = 0;
-		virtual bool isFinished(uint32_t elapsed, int32_t duration) = 0;
-};
+#include "./types.h"
 
 struct FrequencyStepPhase {
 	int16_t adjustment;		// change of frequency per step

--- a/video/envelopes/multiphase_adsr.h
+++ b/video/envelopes/multiphase_adsr.h
@@ -109,7 +109,7 @@ uint8_t MultiphaseADSREnvelope::getVolume(uint8_t baseVolume, uint32_t elapsed, 
 	subPhasePos -= _attackDuration;
 	pos += _attackDuration;
 
-	auto sustainVolume = getTargetVolume(baseVolume, _sustainLevel);	
+	auto sustainVolume = getTargetVolume(baseVolume, _sustainLevel);
 	if (_sustainLoops) {
 		// if we have sustain data, and it's not just zero duration, then loop around it
 		while (pos < duration) {

--- a/video/envelopes/multiphase_adsr.h
+++ b/video/envelopes/multiphase_adsr.h
@@ -95,7 +95,7 @@ uint8_t MultiphaseADSREnvelope::getVolume(uint8_t baseVolume, uint32_t elapsed, 
 	// work out what sub-phase we're on, based on our elapsed time
 	if (subPhasePos < _attackDuration) {
 		// we're in an attack sub-phase
-		for (auto subPhase : *this->_attack) {
+		for (const auto& subPhase : *this->_attack) {
 			if (subPhasePos < subPhase.duration) {
 				// we're inside this sub-phase
 				return map(subPhasePos, 0, subPhase.duration, startVolume, getTargetVolume(baseVolume, subPhase.level));

--- a/video/envelopes/multiphase_adsr.h
+++ b/video/envelopes/multiphase_adsr.h
@@ -1,0 +1,197 @@
+//
+// Title:			Multi-phase ADSR Envelope support
+// Author:			Steve Sims
+// Created:			14/01/2024
+// Last Updated:	14/01/2024
+
+#ifndef ENVELOPE_MULTIPHASE_ADSR_H
+#define ENVELOPE_MULTIPHASE_ADSR_H
+
+#include <memory>
+#include <vector>
+#include <Arduino.h>
+
+#include "./types.h"
+
+struct VolumeSubPhase {
+	uint8_t level;			// relative volume level for sub-phase
+	uint16_t duration;		// number of steps
+};
+
+class MultiphaseADSREnvelope : public VolumeEnvelope {
+	public:
+		MultiphaseADSREnvelope(std::shared_ptr<std::vector<VolumeSubPhase>> attack, std::shared_ptr<std::vector<VolumeSubPhase>> sustain, std::shared_ptr<std::vector<VolumeSubPhase>> release);
+		uint8_t		getVolume(uint8_t baseVolume, uint32_t elapsed, int32_t duration);
+		bool		isReleasing(uint32_t elapsed, int32_t duration);
+		bool 		isFinished(uint32_t elapsed, int32_t duration);
+		uint32_t	getRelease() {
+			return _releaseDuration;
+		};
+	private:
+		uint8_t		getTargetVolume(uint8_t baseVolume, uint8_t level);
+		std::shared_ptr<std::vector<VolumeSubPhase>> _attack;
+		std::shared_ptr<std::vector<VolumeSubPhase>> _sustain;
+		std::shared_ptr<std::vector<VolumeSubPhase>> _release;
+		uint32_t	_attackDuration;
+		uint32_t	_sustainDuration;
+		uint32_t	_releaseDuration;
+		uint8_t		_sustainSubphases;
+		uint8_t		_attackLevel;			// final levels
+		uint8_t		_sustainLevel;
+		uint8_t		_releaseLevel;
+		bool		_sustainLoops;
+};
+
+MultiphaseADSREnvelope::MultiphaseADSREnvelope(std::shared_ptr<std::vector<VolumeSubPhase>> attack, std::shared_ptr<std::vector<VolumeSubPhase>> sustain, std::shared_ptr<std::vector<VolumeSubPhase>> release)
+	: _attack(attack), _sustain(sustain), _release(release)
+{
+	_attackDuration = 0;
+	// add durations from attack subphases to attackDuration
+	for (const auto& subPhase : *_attack) {
+		_attackDuration += subPhase.duration;
+	}
+	_sustainSubphases = _sustain->size();
+	_sustainDuration = 0;
+	for (const auto& subPhase : *_sustain) {
+		_sustainDuration += subPhase.duration;
+	}
+	_releaseDuration = 0;
+	for (const auto& subPhase : *_release) {
+		_releaseDuration += subPhase.duration;
+	}
+	_attackLevel = 127;
+	// set attackLevel to last level from attack vector, if there are values
+	if (!_attack->empty()) {
+		_attackLevel = _attack->back().level;
+	}
+	_sustainLevel = 127;
+	if (!_sustain->empty()) {
+		_sustainLevel = _sustain->back().level;
+	}
+	_releaseLevel = 0;
+	if (!_release->empty()) {
+		_releaseLevel = _release->back().level;
+	}
+	_sustainLoops = false;
+	// loop over our sustain entries, and if we have any non-zero duration values set sustainLoops to true
+	for (const auto& subPhase : *_sustain) {
+		if (subPhase.duration > 0) {
+			_sustainLoops = true;
+			break;
+		}
+	}
+	debug_log("MultiphaseADSREnvelope created with %d attack, %d sustain, %d release phases\n\r", _attack->size(), _sustain->size(), _release->size());
+	debug_log("  attackDuration %d, sustainDuration %d, releaseDuration %d\n\r", _attackDuration, _sustainDuration, _releaseDuration);
+	debug_log("  attackLevel %d, sustainLevel %d, releaseLevel %d\n\r", _attackLevel, _sustainLevel, _releaseLevel);
+	for (auto subPhase : *this->_attack) {
+		debug_log("  level %d, duration %d\n\r", subPhase.level, subPhase.duration);
+	}
+}
+
+uint8_t MultiphaseADSREnvelope::getVolume(uint8_t baseVolume, uint32_t elapsed, int32_t duration) {
+	auto subPhasePos = elapsed;
+	uint32_t pos = 0;
+	uint8_t startVolume = 0;
+	// work out what sub-phase we're on, based on our elapsed time
+	if (subPhasePos < _attackDuration) {
+		// we're in an attack sub-phase
+		for (auto subPhase : *this->_attack) {
+			if (subPhasePos < subPhase.duration) {
+				// we're inside this sub-phase
+				return map(subPhasePos, 0, subPhase.duration, startVolume, getTargetVolume(baseVolume, subPhase.level));
+			}
+			subPhasePos -= subPhase.duration;
+			startVolume = getTargetVolume(baseVolume, subPhase.level);
+		}
+	} else {
+		startVolume = getTargetVolume(baseVolume, _attackLevel);
+	}
+	subPhasePos -= _attackDuration;
+	pos += _attackDuration;
+
+	auto sustainVolume = getTargetVolume(baseVolume, _sustainLevel);	
+	if (_sustainLoops) {
+		// if we have sustain data, and it's not just zero duration, then loop around it
+		while (pos < duration) {
+			// short-cut looping sub-phases if we can for complete loops
+			if (subPhasePos > _sustainDuration) {
+				subPhasePos -= _sustainDuration;
+				pos += _sustainDuration;
+				startVolume = sustainVolume;
+			} else {
+				for (auto subPhase : *this->_sustain) {
+					if (subPhasePos < subPhase.duration) {
+						// we're in this sub-phase
+						return map(subPhasePos, 0, subPhase.duration, startVolume, getTargetVolume(baseVolume, subPhase.level));
+					}
+					subPhasePos -= subPhase.duration;
+					pos += subPhase.duration;
+					startVolume = getTargetVolume(baseVolume, subPhase.level);
+				}
+			}
+		}
+	} else if (elapsed < duration) {
+		// non-looping sustain - so we're spreading time between the phases, if there are any
+		if (_sustainSubphases <= 1) {
+			return map(subPhasePos, 0, duration - _attackDuration, startVolume, sustainVolume);
+		}
+		int phaseDuration = (duration - _attackDuration) / _sustainSubphases;
+		for (auto subPhase : *this->_sustain) {
+			if (subPhasePos < phaseDuration) {
+				// we're in this subphase
+				return map(subPhasePos, 0, phaseDuration, startVolume, getTargetVolume(baseVolume, subPhase.level));
+			}
+			subPhasePos -= phaseDuration;
+			startVolume = getTargetVolume(baseVolume, subPhase.level);
+		}
+		return startVolume;
+	} else {
+		// end of sustain reached for non-looping sustain, so adjust our subPhasePos to our time within release
+		subPhasePos = elapsed - duration;
+		startVolume = sustainVolume;
+	}
+
+	// work out our release phase volume
+	for (auto subPhase : *this->_release) {
+		if (subPhasePos < subPhase.duration) {
+			return map(subPhasePos, 0, subPhase.duration, startVolume, getTargetVolume(baseVolume, subPhase.level));
+		}
+		subPhasePos -= subPhase.duration;
+		startVolume = getTargetVolume(baseVolume, subPhase.level);
+	}
+
+	return 0;
+}
+
+bool MultiphaseADSREnvelope::isReleasing(uint32_t elapsed, int32_t duration) {
+	if (duration < 0) return false;
+	auto minDuration = this->_attackDuration;
+	if (duration < minDuration) duration = minDuration;
+
+	// NB this is an approximation.  we may not actually be using "release" phase of envelope
+	// but we'll consider ourselves to be in the "release" if the following check is true
+	// this is good enough for the channel state machine, as the isFinished check is correct
+	return (elapsed >= duration);
+}
+
+bool MultiphaseADSREnvelope::isFinished(uint32_t elapsed, int32_t duration) {
+	if (duration < 0) return false;
+
+	// we're finished if we have reached the end of sustain and then end of release
+	auto minDuration = _attackDuration + _sustainDuration;
+	if (_sustainDuration != 0) {
+		while ((minDuration + _sustainDuration) <= duration) {
+			minDuration += _sustainDuration;
+		}
+	}
+
+	if (duration < minDuration) duration = minDuration;
+
+	return (elapsed >= duration + this->_releaseDuration);
+}
+
+uint8_t MultiphaseADSREnvelope::getTargetVolume(uint8_t baseVolume, uint8_t level) {
+	return baseVolume * level / 127;
+}
+
+#endif // ENVELOPE_MULTIPHASE_ADSR_H

--- a/video/envelopes/types.h
+++ b/video/envelopes/types.h
@@ -1,0 +1,26 @@
+//
+// Title:			Audio Envelope support
+// Author:			Steve Sims
+// Created:			14/01/2024
+// Last Updated:	14/01/2024
+
+#ifndef ENVELOPE_TYPES_H
+#define ENVELOPE_TYPES_H
+
+#include <memory>
+
+class VolumeEnvelope {
+	public:
+		virtual uint8_t getVolume(uint8_t baseVolume, uint32_t elapsed, int32_t duration) = 0;
+		virtual bool isReleasing(uint32_t elapsed, int32_t duration) = 0;
+		virtual bool isFinished(uint32_t elapsed, int32_t duration) = 0;
+		virtual uint32_t getRelease() = 0;
+};
+
+class FrequencyEnvelope {
+	public:
+		virtual uint16_t getFrequency(uint16_t baseFrequency, uint32_t elapsed, int32_t duration) = 0;
+		virtual bool isFinished(uint32_t elapsed, int32_t duration) = 0;
+};
+
+#endif // ENVELOPE_TYPES_H

--- a/video/vdu.h
+++ b/video/vdu.h
@@ -22,9 +22,9 @@ void VDUStreamProcessor::vdu(uint8_t c) {
 	if (consoleMode) {
 		DBGSerial.write(c);
 	}
-	
+
 	switch(c) {
-		case 0x04:	
+		case 0x04:
 			// enable text cursor
 			setCharacterOverwrite(true);
 			setActiveCursor(getTextCursor());
@@ -39,22 +39,22 @@ void VDUStreamProcessor::vdu(uint8_t c) {
 		case 0x07:	// Bell
 			playNote(0, 100, 750, 125);
 			break;
-		case 0x08:  // Cursor Left
+		case 0x08:	// Cursor Left
 			cursorLeft();
 			break;
-		case 0x09:  // Cursor Right
+		case 0x09:	// Cursor Right
 			cursorRight();
 			break;
-		case 0x0A:  // Cursor Down
+		case 0x0A:	// Cursor Down
 			cursorDown();
 			break;
-		case 0x0B:  // Cursor Up
+		case 0x0B:	// Cursor Up
 			cursorUp();
 			break;
-		case 0x0C:  // CLS
+		case 0x0C:	// CLS
 			cls(false);
 			break;
-		case 0x0D:  // CR
+		case 0x0D:	// CR
 			cursorCR();
 			break;
 		case 0x0E:	// Paged mode ON
@@ -69,22 +69,22 @@ void VDUStreamProcessor::vdu(uint8_t c) {
 		case 0x11:	// COLOUR
 			vdu_colour();
 			break;
-		case 0x12:  // GCOL
+		case 0x12:	// GCOL
 			vdu_gcol();
 			break;
 		case 0x13:	// Define Logical Colour
 			vdu_palette();
 			break;
-		case 0x16:  // Mode
+		case 0x16:	// Mode
 			vdu_mode();
 			break;
-		case 0x17:  // VDU 23
+		case 0x17:	// VDU 23
 			vdu_sys();
 			break;
 		case 0x18:	// Define a graphics viewport
 			vdu_graphicsViewport();
 			break;
-		case 0x19:  // PLOT
+		case 0x19:	// PLOT
 			vdu_plot();
 			break;
 		case 0x1A:	// Reset text and graphics viewports
@@ -110,14 +110,14 @@ void VDUStreamProcessor::vdu(uint8_t c) {
 		case 0x80 ... 0xFF:
 			plotCharacter(c);
 			break;
-		case 0x7F:  // Backspace
+		case 0x7F:	// Backspace
 			plotBackspace();
 			break;
 	}
 }
 
 // VDU 17 Handle COLOUR
-// 
+//
 void VDUStreamProcessor::vdu_colour() {
 	auto colour = readByte_t();
 
@@ -125,7 +125,7 @@ void VDUStreamProcessor::vdu_colour() {
 }
 
 // VDU 18 Handle GCOL
-// 
+//
 void VDUStreamProcessor::vdu_gcol() {
 	auto mode = readByte_t();
 	auto colour = readByte_t();
@@ -151,7 +151,7 @@ void VDUStreamProcessor::vdu_mode() {
 	auto mode = readByte_t();
 	debug_log("vdu_mode: %d\n\r", mode);
 	if (mode >= 0) {
-	  	set_mode(mode);
+		set_mode(mode);
 		sendModeInformation();
 		if (mouseEnabled) {
 			sendMouseData();
@@ -214,7 +214,7 @@ void VDUStreamProcessor::vdu_plot() {
 		default:
 			// 1, 3, 5, 7 are all draw modes
 			switch (operation) {
-				case 0x00: 	// line
+				case 0x00:	// line
 					plotLine();
 					break;
 				case 0x08:	// line, omitting last point
@@ -226,7 +226,7 @@ void VDUStreamProcessor::vdu_plot() {
 				case 0x38:	// dot-dash line, omitting both, pattern continued
 					debug_log("plot dot-dash line not implemented\n\r");
 					break;
-				case 0x20: 	// solid line, first point omitted
+				case 0x20:	// solid line, first point omitted
 					plotLine(true, false);
 					break;
 				case 0x28:	// solid line, first and last points omitted
@@ -323,8 +323,8 @@ void VDUStreamProcessor::vdu_textViewport() {
 		if (cx2 > 39) cx2 = 39;
 		if (cy2 > 24) cy2 = 24;
 		if (cx2 >= cx1 && cy2 >= cy1)
-	    ttxt_instance.set_window(cx1,cy2,cx2,cy1);
-	}	
+		ttxt_instance.set_window(cx1,cy2,cx2,cy1);
+	}
 	if (setTextViewport(x1, y1, x2, y2)) {
 		ensureCursorInViewport(textViewport);
 		debug_log("vdu_textViewport: OK %d,%d,%d,%d\n\r", x1, y1, x2, y2);

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -67,7 +67,7 @@ void VDUStreamProcessor::vdu_sys_audio() {
 			auto action = readByte_t();		if (action == -1) return;
 
 			// sample number is negative 8 bit number, and provided in channel number param
-			int16_t sampleNum = BUFFERED_SAMPLE_BASEID + (-(int8_t)channel - 1);	// convert to positive, ranged from zero
+			uint16_t sampleNum = BUFFERED_SAMPLE_BASEID + (-(int8_t)channel - 1);	// convert to positive, ranged from zero
 
 			switch (action) {
 				case AUDIO_SAMPLE_LOAD: {
@@ -133,10 +133,11 @@ void VDUStreamProcessor::vdu_sys_audio() {
 				}	break;
 
 				case AUDIO_SAMPLE_DEBUG_INFO: {
-					debug_log("Sample info: %d (%d)\n\r", (int8_t)channel, sampleNum);
+					auto bufferId = readWord_t();	if (bufferId == -1) return;
+					debug_log("Sample info: %d\n\r", bufferId);
 					debug_log("  samples count: %d\n\r", samples.size());
 					debug_log("  free mem: %d\n\r", heap_caps_get_free_size(MALLOC_CAP_8BIT));
-					auto sample = samples[sampleNum];
+					auto sample = samples[bufferId];
 					if (!sample) {
 						debug_log("  sample is null\n\r");
 						break;

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -211,6 +211,14 @@ void VDUStreamProcessor::vdu_sys_audio() {
 
 			sendAudioStatus(channel, setSampleRate(channel, sampleRate));
 		}	break;
+
+		case AUDIO_CMD_SET_PARAM: {
+			auto param = readByte_t();		if (param == -1) return;
+			auto use16Bit = param & AUDIO_PARAM_16BIT;
+			auto value = use16Bit ? readWord_t() : readByte_t();	if (value == -1) return;
+
+			sendAudioStatus(channel, setParameter(channel, param, value));
+		}	break;
 	}
 }
 
@@ -364,6 +372,15 @@ uint8_t VDUStreamProcessor::setSampleRepeatLength(uint16_t sampleId, uint32_t re
 	}
 	samples[sampleId]->repeatLength = repeatLength;
 	return 1;
+}
+
+// Set channel/waveform parameter
+//
+uint8_t VDUStreamProcessor::setParameter(uint8_t channel, uint8_t parameter, uint16_t value) {
+	if (channelEnabled(channel)) {
+		return audioChannels[channel]->setParameter(parameter, value);
+	}
+	return 0;
 }
 
 #endif // VDU_AUDIO_H

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -60,6 +60,7 @@ class VDUStreamProcessor {
 		uint8_t setSampleFrequency(uint16_t bufferId, uint16_t frequency);
 		uint8_t setSampleRepeatStart(uint16_t bufferId, uint32_t offset);
 		uint8_t setSampleRepeatLength(uint16_t bufferId, uint32_t length);
+		uint8_t setParameter(uint8_t channel, uint8_t parameter, uint16_t value);
 
 		void vdu_sys_sprites();
 		void receiveBitmap(uint16_t bufferId, uint16_t width, uint16_t height);

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -55,8 +55,8 @@ class VDUStreamProcessor {
 		void sendAudioStatus(uint8_t channel, uint8_t status);
 		uint8_t loadSample(uint16_t bufferId, uint32_t length);
 		uint8_t createSampleFromBuffer(uint16_t bufferId, uint8_t format, uint16_t sampleRate);
-		void setVolumeEnvelope(uint8_t channel, uint8_t type);
-		void setFrequencyEnvelope(uint8_t channel, uint8_t type);
+		uint8_t setVolumeEnvelope(uint8_t channel, uint8_t type);
+		uint8_t setFrequencyEnvelope(uint8_t channel, uint8_t type);
 		uint8_t setSampleFrequency(uint16_t bufferId, uint16_t frequency);
 		uint8_t setSampleRepeatStart(uint16_t bufferId, uint32_t offset);
 		uint8_t setSampleRepeatLength(uint16_t bufferId, uint32_t length);

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -74,7 +74,7 @@ void VDUStreamProcessor::vdu_sys() {
 	else if (mode < 32) {
 		switch (mode) {
 			case 0x00: {					// VDU 23, 0
-	  			vdu_sys_video();			// Video system control
+				vdu_sys_video();			// Video system control
 			}	break;
 			case 0x01: {					// VDU 23, 1
 				auto b = readByte_t();		// Cursor control
@@ -83,7 +83,7 @@ void VDUStreamProcessor::vdu_sys() {
 				}
 			}	break;
 			case 0x07: {					// VDU 23, 7
-				vdu_sys_scroll();			// Scroll 
+				vdu_sys_scroll();			// Scroll
 			}	break;
 			case 0x10: {					// VDU 23, 16
 				vdu_sys_cursorBehaviour();	// Set cursor behaviour
@@ -131,7 +131,7 @@ void VDUStreamProcessor::vdu_sys_video() {
 			auto x = readWord_t();		// Get pixel value at screen position x, y
 			auto y = readWord_t();
 			sendScreenPixel((short)x, (short)y);
-		}	break;		
+		}	break;
 		case VDP_AUDIO: {				// VDU 23, 0, &85, channel, command, <args>
 			vdu_sys_audio();
 		}	break;
@@ -197,7 +197,7 @@ void VDUStreamProcessor::vdu_sys_video() {
 		case VDP_TERMINALMODE: {		// VDU 23, 0, &FF
 			startTerminal();		 	// Switch to, or resume, terminal mode
 		}	break;
-  	}
+	}
 }
 
 // VDU 23, 0, &80, <echo>: Send a general poll/echo byte back to MOS
@@ -212,7 +212,7 @@ void VDUStreamProcessor::sendGeneralPoll() {
 		(uint8_t) (b & 0xFF),
 	};
 	send_packet(PACKET_GP, sizeof packet, packet);
-	initialised = true;	
+	initialised = true;
 }
 
 // VDU 23, 0, &81, <region>: Set the keyboard layout
@@ -229,9 +229,9 @@ void VDUStreamProcessor::sendCursorPosition() {
 		(uint8_t) ((textCursor.X - textViewport.X1)/ fontW),
 		(uint8_t) ((textCursor.Y - textViewport.Y1)/ fontH),
 	};
-	send_packet(PACKET_CURSOR, sizeof packet, packet);	
+	send_packet(PACKET_CURSOR, sizeof packet, packet);
 }
-	
+
 // VDU 23, 0, &83 Send a character back to MOS
 //
 void VDUStreamProcessor::sendScreenChar(uint16_t x, uint16_t y) {
@@ -257,7 +257,7 @@ void VDUStreamProcessor::sendScreenPixel(uint16_t x, uint16_t y) {
 		pixel.B,
 		pixelIndex,	// And the pixel index in the palette
 	};
-	send_packet(PACKET_SCRPIXEL, sizeof packet, packet);	
+	send_packet(PACKET_SCRPIXEL, sizeof packet, packet);
 }
 
 // VDU 23, 0, &94, index: Send a colour back to MOS
@@ -295,7 +295,7 @@ void VDUStreamProcessor::sendColour(uint8_t colour) {
 		pixel.B,
 		colour,
 	};
-	send_packet(PACKET_SCRPIXEL, sizeof packet, packet);	
+	send_packet(PACKET_SCRPIXEL, sizeof packet, packet);
 }
 
 // VDU 23, 0, &87, 0: Send TIME information (from ESP32 RTC)
@@ -343,7 +343,7 @@ void VDUStreamProcessor::vdu_sys_video_time() {
 		auto yr = readByte_t(); if (yr == -1) return;
 		auto mo = readByte_t(); if (mo == -1) return;
 		auto da = readByte_t(); if (da == -1) return;
-		auto ho = readByte_t(); if (ho == -1) return;	
+		auto ho = readByte_t(); if (ho == -1) return;
 		auto mi = readByte_t(); if (mi == -1) return;
 		auto se = readByte_t(); if (se == -1) return;
 
@@ -530,7 +530,7 @@ void VDUStreamProcessor::vdu_sys_scroll() {
 
 
 // VDU 23,16: Set cursor behaviour
-// 
+//
 void VDUStreamProcessor::vdu_sys_cursorBehaviour() {
 	auto setting = readByte_t();	if (setting == -1) return;
 	auto mask = readByte_t();		if (mask == -1) return;
@@ -551,7 +551,7 @@ void VDUStreamProcessor::vdu_sys_udg(char c) {
 			return;
 		}
 		buffer[i] = b;
-	}	
+	}
 
 	redefineCharacter(c, buffer);
 }

--- a/video/video.ino
+++ b/video/video.ino
@@ -82,9 +82,9 @@ void setup() {
 	set_mode(1);
 	setupVDPProtocol();
 	processor = new VDUStreamProcessor(&VDPSerial);
+	initAudio();
 	processor->wait_eZ80();
 	setupKeyboardAndMouse();
-	initAudio();
 	processor->sendModeInformation();
 	boot_screen();
 }


### PR DESCRIPTION
ensure all audio commands return a status value

only exceptions to this are comms timeouts, and even then some will result in a returned failure value

this fills in some gaps in the audio API with some calls that were not returning values.  if all calls return values then that makes it simpler to detect whether features are present and supported or not

Also allow samples being played to continue playing if volume is set/adjusted to zero.  They will continue to play (until completion) allowing their volume to be ramped back up.  Other mechanisms of aborting sample playback, such as changing to play a different sample, or setting duration to zero, will continue to work.  A channel playing a zero volume sample will allow "play note" to function to start a new note

Set volume command now supports adjusting system volume level by specifying channel -1 (or 255), plus will now return the volume level instead of just 0/1 for failure/success

new volume envelope type multi-phase ADSR added

new command to set parameter on channel added.  this allows for the duty cycle on square waves to be adjusted

documentation on these changes can be seen in AgonConsole8/agon-docs#12