### PR TITLE
Buffer copy ref

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -197,6 +197,8 @@ enum AudioState : uint8_t {	// Audio channel state
 
 #define BUFFERED_DEBUG_INFO		0x20	// Get debug info about a buffer
 
+#define BUFFERED_COPY_REF	    0x2D	// Copy references to blocks from multiple buffers into one buffer
+
 // Adjust operation codes
 #define ADJUST_NOT				0x00	// Adjust: NOT
 #define ADJUST_NEG				0x01	// Adjust: Negative

--- a/video/agon.h
+++ b/video/agon.h
@@ -194,10 +194,9 @@ enum AudioState : uint8_t {	// Audio channel state
 #define BUFFERED_SPREAD_FROM	0x16	// Spread blocks from target buffer ID onwards
 #define BUFFERED_REVERSE_BLOCKS	0x17	// Reverse the order of blocks in a buffer
 #define BUFFERED_REVERSE		0x18	// Reverse the order of data in a buffer
+#define BUFFERED_COPY_REF		0x19	// Copy references to blocks from multiple buffers into one buffer
 
 #define BUFFERED_DEBUG_INFO		0x20	// Get debug info about a buffer
-
-#define BUFFERED_COPY_REF	    0x2D	// Copy references to blocks from multiple buffers into one buffer
 
 // Adjust operation codes
 #define ADJUST_NOT				0x00	// Adjust: NOT

--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -253,10 +253,7 @@ void VDUStreamProcessor::bufferCall(uint16_t callBufferId, uint32_t offset) {
 void VDUStreamProcessor::bufferClear(uint16_t bufferId) {
 	debug_log("bufferClear: buffer %d\n\r", bufferId);
 	if (bufferId == 65535) {
-		// iterate thru our buffers and clear their vectors
-		for (auto &bufferPair : buffers) {
-			bufferPair.second.clear();
-		}
+		buffers.clear();
 		resetBitmaps();
 		resetSamples();
 		return;
@@ -265,7 +262,7 @@ void VDUStreamProcessor::bufferClear(uint16_t bufferId) {
 		debug_log("bufferClear: buffer %d not found\n\r", bufferId);
 		return;
 	}
-	buffers[bufferId].clear();
+	buffers.erase(bufferId);
 	clearBitmap(bufferId);
 	clearSample(bufferId);
 	debug_log("bufferClear: cleared buffer %d\n\r", bufferId);

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -90,6 +90,7 @@ class VDUStreamProcessor {
 		void bufferSpreadInto(uint16_t bufferId, std::vector<uint16_t> newBufferIds, bool iterate);
 		void bufferReverseBlocks(uint16_t bufferId);
 		void bufferReverse(uint16_t bufferId, uint8_t options);
+		void bufferCopyRef(uint16_t bufferId, std::vector<uint16_t> sourceBufferIds);
 
 		void vdu_sys_updater();
 		void unlock();


### PR DESCRIPTION
A version of the buffer copy command that just copies references to the blocks.  This speeds up situations where you're pulling in  data from various buffers to consolidate because the data only needs to be copied once.