### PR TITLE
add support for VDU 2 and co

### DIFF
--- a/video/graphics.h
+++ b/video/graphics.h
@@ -203,6 +203,24 @@ fabgl::PaintOptions getPaintOptions(uint8_t mode, fabgl::PaintOptions priorPaint
 	return p;
 }
 
+// Restore palette to default for current mode
+//
+void restorePalette() {
+	switch (getVGAColourDepth()) {
+		case  2: resetPalette(defaultPalette02); break;
+		case  4: resetPalette(defaultPalette04); break;
+		case  8: resetPalette(defaultPalette08); break;
+		case 16: resetPalette(defaultPalette10); break;
+		case 64: resetPalette(defaultPalette40); break;
+	}
+	gfg = colourLookup[0x3F];
+	gbg = colourLookup[0x00];
+	tfg = colourLookup[0x3F];
+	tbg = colourLookup[0x00];
+	tpo = getPaintOptions(0, tpo);
+	gpo = getPaintOptions(0, gpo);
+}
+
 // Set text colour (handles COLOUR / VDU 17)
 //
 void setTextColour(uint8_t colour) {
@@ -709,19 +727,7 @@ int8_t change_mode(uint8_t mode) {
 	if (errVal != 0) {
 		return errVal;
 	}
-	switch (getVGAColourDepth()) {
-		case  2: resetPalette(defaultPalette02); break;
-		case  4: resetPalette(defaultPalette04); break;
-		case  8: resetPalette(defaultPalette08); break;
-		case 16: resetPalette(defaultPalette10); break;
-		case 64: resetPalette(defaultPalette40); break;
-	}
-	tpo = getPaintOptions(0, tpo);
-	gpo = getPaintOptions(0, gpo);
-	gfg = colourLookup[0x3F];
-	gbg = colourLookup[0x00];
-	tfg = colourLookup[0x3F];
-	tbg = colourLookup[0x00];
+	restorePalette();
 	if (!ttxtMode) {
 		canvas->selectFont(&fabgl::FONT_AGON);
 	}

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -15,6 +15,7 @@ class VDUStreamProcessor {
 		std::shared_ptr<Stream> inputStream;
 		std::shared_ptr<Stream> outputStream;
 		std::shared_ptr<Stream> originalOutputStream;
+		bool commandsEnabled = true;
 
 		int16_t readByte_t(uint16_t timeout);
 		int32_t readWord_t(uint16_t timeout);
@@ -33,6 +34,8 @@ class VDUStreamProcessor {
 		void vdu_textViewport();
 		void vdu_origin();
 		void vdu_cursorTab();
+
+		void vdu_print(uint8_t c);
 
 		void vdu_sys();
 		void vdu_sys_video();

--- a/video/video.ino
+++ b/video/video.ino
@@ -58,6 +58,7 @@ HardwareSerial	DBGSerial(0);
 
 TerminalState	terminalState = TerminalState::Disabled;		// Terminal state (for CP/M, etc)
 bool			consoleMode = false;			// Serial console mode (0 = off, 1 = console enabled)
+bool			printerOn = false;				// Output "printer" to debug serial link
 
 #include "version.h"							// Version information
 #include "agon_ps2.h"							// Keyboard support
@@ -130,9 +131,20 @@ void do_keyboard() {
 	if (getKeyboardKey(&keycode, &modifiers, &vk, &down)) {
 		// Handle some control keys
 		//
-		switch (keycode) {
-			case 14: setPagedMode(true); break;
-			case 15: setPagedMode(false); break;
+		if (down) {
+			switch (keycode) {
+				case 2:		// printer on
+				case 3:		// printer off
+				case 6:		// VDU commands enable
+				case 7:		// Bell
+				case 12:	// CLS
+				case 14 ... 15:	// paged mode on/off
+					processor->vdu(keycode);
+					break;
+				case 16:
+					// control-P toggles "printer" on R.T.Russell's BASIC
+					printerOn = !printerOn;
+			}
 		}
 		// Create and send the packet back to MOS
 		//


### PR DESCRIPTION
VDU 2 and 3 are supported to enable and disable “printer”, which for our purposes on Agon is the debug serial terminal

VDU 1 will send next character to printer only

VDU 21 will disable the VDU command processor, allowing only output to “printer” - only VDU 1 and 6 commands will be processed

VDU 6 re-enables the command processor

VDU 20 (reset palette) added for good measure, as it was missing

various extra control keys are now supported on the VDP (ctrl B, C, F, G, L, N and O) and work as on Acorn systems (mirroring VDU 2, VDU 3, VDU 6 etc). ctrl-P is also supported, but toggles printer rather than performing a CLG, matching RTRussell’s BASIC

NB the processing of VDU 21 / VDU 6 currently differs from Acorn systems.  On an Acorn system, after performing a VDU 21, subsequent VDU commands will still be attempted to be received in their entirety, but just would not be executed.  So, for instance, performing a `VDU 22, 6` would be ignored on an Acorn system, as the VDU 22 command (change mode) is expecting a byte.  On an Agon system with these changes the `VDU 22` byte alone would be ignored, and the `6` would be interpreted as a plain `VDU 6`.