### PR TITLE
Buffers are now removed when cleared

### DIFF
--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -244,10 +244,7 @@ void VDUStreamProcessor::bufferCall(uint16_t callBufferId, uint32_t offset) {
 void VDUStreamProcessor::bufferClear(uint16_t bufferId) {
 	debug_log("bufferClear: buffer %d\n\r", bufferId);
 	if (bufferId == 65535) {
-		// iterate thru our buffers and clear their vectors
-		for (auto bufferPair : buffers) {
-			bufferPair.second.clear();
-		}
+        buffers.clear();
 		resetBitmaps();
 		resetSamples();
 		return;
@@ -256,7 +253,7 @@ void VDUStreamProcessor::bufferClear(uint16_t bufferId) {
 		debug_log("bufferClear: buffer %d not found\n\r", bufferId);
 		return;
 	}
-	buffers[bufferId].clear();
+    buffers.erase(bufferId);
 	clearBitmap(bufferId);
 	clearSample(bufferId);
 	debug_log("bufferClear: cleared buffer %d\n\r", bufferId);


### PR DESCRIPTION
Some commands (bufferCreate for example) check to see if the buffer already exists by checking if the bufferId exists in the "buffers" map.  Therefore, it is not enough to just empty a buffer's block list when it is cleared.  It needs removing from the map too.
