### PR TITLE
Copy and consolidate

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -125,13 +125,13 @@
 #define AUDIO_FORMAT_WITH_RATE		8	// OR this with the format to indicate a sample rate follows
 #define AUDIO_FORMAT_TUNEABLE		16	// OR this with the format to indicate sample can be tuned (frequency adjustable)
 
-#define AUDIO_ENVELOPE_NONE		0		// No envelope
-#define AUDIO_ENVELOPE_ADSR		1		// Simple ADSR volume envelope
+#define AUDIO_ENVELOPE_NONE			0		// No envelope
+#define AUDIO_ENVELOPE_ADSR			1		// Simple ADSR volume envelope
 #define AUDIO_ENVELOPE_MULTIPHASE_ADSR		2		// Multi-phase ADSR envelope
 
 #define AUDIO_FREQUENCY_ENVELOPE_STEPPED	1		// Stepped frequency envelope
 
-#define AUDIO_FREQUENCY_REPEATS 0x01	// Repeat/loop the frequency envelope
+#define AUDIO_FREQUENCY_REPEATS		0x01	// Repeat/loop the frequency envelope
 #define AUDIO_FREQUENCY_CUMULATIVE	0x02	// Reset frequency envelope when looping
 #define AUDIO_FREQUENCY_RESTRICT	0x04	// Restrict frequency envelope to the range 0-65535
 
@@ -169,43 +169,43 @@ enum AudioState : uint8_t {	// Audio channel state
 #define MOUSE_SET_ACCERATION	9		// Set mouse acceleration (1-2000)
 #define MOUSE_SET_WHEELACC		10		// Set mouse wheel acceleration
 
-#define MOUSE_DEFAULT_CURSOR	0;		// Default mouse cursor
-#define MOUSE_DEFAULT_SAMPLERATE	60;	// Default mouse sample rate
-#define MOUSE_DEFAULT_RESOLUTION	2;	// Default mouse resolution (4 counts/mm)
-#define MOUSE_DEFAULT_SCALING	1;		// Default mouse scaling (1:1)
+#define MOUSE_DEFAULT_CURSOR		0;		// Default mouse cursor
+#define MOUSE_DEFAULT_SAMPLERATE	60;		// Default mouse sample rate
+#define MOUSE_DEFAULT_RESOLUTION	2;		// Default mouse resolution (4 counts/mm)
+#define MOUSE_DEFAULT_SCALING		1;		// Default mouse scaling (1:1)
 #define MOUSE_DEFAULT_ACCELERATION	180;	// Default mouse acceleration 
 #define MOUSE_DEFAULT_WHEELACC		60000;	// Default mouse wheel acceleration
 
 // Buffered commands
-#define BUFFERED_WRITE			        0x00	// Write to a numbered buffer
-#define BUFFERED_CALL			        0x01	// Call buffered commands
-#define BUFFERED_CLEAR			        0x02	// Clear buffered commands
-#define BUFFERED_CREATE			        0x03	// Create a new empty buffer
-#define BUFFERED_SET_OUTPUT		        0x04	// Set the output buffer
-#define BUFFERED_ADJUST			        0x05	// Adjust buffered commands
-#define BUFFERED_COND_CALL		        0x06	// Conditionally call a buffer
-#define BUFFERED_JUMP			        0x07	// Jump to a buffer
-#define BUFFERED_COND_JUMP		        0x08	// Conditionally jump to a buffer
-#define BUFFERED_OFFSET_JUMP	        0x09	// Jump to a buffer with an offset
-#define BUFFERED_OFFSET_COND_JUMP	    0x0A	// Conditionally jump to a buffer with an offset
-#define BUFFERED_OFFSET_CALL	        0x0B	// Call a buffer with an offset
-#define BUFFERED_OFFSET_COND_CALL	    0x0C	// Conditionally call a buffer with an offset
-#define BUFFERED_COPY			        0x0D	// Copy blocks from multiple buffers into one buffer
-#define BUFFERED_CONSOLIDATE	        0x0E	// Consolidate blocks inside a buffer into one
-#define BUFFERED_SPLIT			        0x0F	// Split a buffer into multiple blocks
-#define BUFFERED_SPLIT_INTO		        0x10	// Split a buffer into multiple blocks to new buffer(s)
-#define BUFFERED_SPLIT_FROM		        0x11	// Split to new buffers from a target bufferId onwards
-#define BUFFERED_SPLIT_BY		        0x12	// Split a buffer into multiple blocks by width (columns)
-#define BUFFERED_SPLIT_BY_INTO	        0x13	// Split by width into new buffer(s)
-#define BUFFERED_SPLIT_BY_FROM	        0x14	// Split by width to new buffers from a target bufferId onwards
-#define BUFFERED_SPREAD_INTO	        0x15	// Spread blocks from a buffer to multiple target buffers
-#define BUFFERED_SPREAD_FROM	        0x16	// Spread blocks from target buffer ID onwards
-#define BUFFERED_REVERSE_BLOCKS	        0x17	// Reverse the order of blocks in a buffer
-#define BUFFERED_REVERSE		        0x18	// Reverse the order of data in a buffer
-#define BUFFERED_COPY_REF		        0x19	// Copy references to blocks from multiple buffers into one buffer
-#define BUFFERED_COPY_AND_CONSOLIDATE   0x1A	// Copy blocks from multiple buffers into one buffer and consolidate them
+#define BUFFERED_WRITE					0x00	// Write to a numbered buffer
+#define BUFFERED_CALL					0x01	// Call buffered commands
+#define BUFFERED_CLEAR					0x02	// Clear buffered commands
+#define BUFFERED_CREATE					0x03	// Create a new empty buffer
+#define BUFFERED_SET_OUTPUT				0x04	// Set the output buffer
+#define BUFFERED_ADJUST					0x05	// Adjust buffered commands
+#define BUFFERED_COND_CALL				0x06	// Conditionally call a buffer
+#define BUFFERED_JUMP					0x07	// Jump to a buffer
+#define BUFFERED_COND_JUMP				0x08	// Conditionally jump to a buffer
+#define BUFFERED_OFFSET_JUMP			0x09	// Jump to a buffer with an offset
+#define BUFFERED_OFFSET_COND_JUMP		0x0A	// Conditionally jump to a buffer with an offset
+#define BUFFERED_OFFSET_CALL			0x0B	// Call a buffer with an offset
+#define BUFFERED_OFFSET_COND_CALL		0x0C	// Conditionally call a buffer with an offset
+#define BUFFERED_COPY					0x0D	// Copy blocks from multiple buffers into one buffer
+#define BUFFERED_CONSOLIDATE			0x0E	// Consolidate blocks inside a buffer into one
+#define BUFFERED_SPLIT					0x0F	// Split a buffer into multiple blocks
+#define BUFFERED_SPLIT_INTO				0x10	// Split a buffer into multiple blocks to new buffer(s)
+#define BUFFERED_SPLIT_FROM				0x11	// Split to new buffers from a target bufferId onwards
+#define BUFFERED_SPLIT_BY				0x12	// Split a buffer into multiple blocks by width (columns)
+#define BUFFERED_SPLIT_BY_INTO			0x13	// Split by width into new buffer(s)
+#define BUFFERED_SPLIT_BY_FROM			0x14	// Split by width to new buffers from a target bufferId onwards
+#define BUFFERED_SPREAD_INTO			0x15	// Spread blocks from a buffer to multiple target buffers
+#define BUFFERED_SPREAD_FROM			0x16	// Spread blocks from target buffer ID onwards
+#define BUFFERED_REVERSE_BLOCKS			0x17	// Reverse the order of blocks in a buffer
+#define BUFFERED_REVERSE				0x18	// Reverse the order of data in a buffer
+#define BUFFERED_COPY_REF				0x19	// Copy references to blocks from multiple buffers into one buffer
+#define BUFFERED_COPY_AND_CONSOLIDATE	0x1A	// Copy blocks from multiple buffers into one buffer and consolidate them
 
-#define BUFFERED_DEBUG_INFO		        0x20	// Get debug info about a buffer
+#define BUFFERED_DEBUG_INFO				0x20	// Get debug info about a buffer
 
 // Adjust operation codes
 #define ADJUST_NOT				0x00	// Adjust: NOT

--- a/video/agon.h
+++ b/video/agon.h
@@ -177,34 +177,35 @@ enum AudioState : uint8_t {	// Audio channel state
 #define MOUSE_DEFAULT_WHEELACC		60000;	// Default mouse wheel acceleration
 
 // Buffered commands
-#define BUFFERED_WRITE			0x00	// Write to a numbered buffer
-#define BUFFERED_CALL			0x01	// Call buffered commands
-#define BUFFERED_CLEAR			0x02	// Clear buffered commands
-#define BUFFERED_CREATE			0x03	// Create a new empty buffer
-#define BUFFERED_SET_OUTPUT		0x04	// Set the output buffer
-#define BUFFERED_ADJUST			0x05	// Adjust buffered commands
-#define BUFFERED_COND_CALL		0x06	// Conditionally call a buffer
-#define BUFFERED_JUMP			0x07	// Jump to a buffer
-#define BUFFERED_COND_JUMP		0x08	// Conditionally jump to a buffer
-#define BUFFERED_OFFSET_JUMP	0x09	// Jump to a buffer with an offset
-#define BUFFERED_OFFSET_COND_JUMP	0x0A	// Conditionally jump to a buffer with an offset
-#define BUFFERED_OFFSET_CALL	0x0B	// Call a buffer with an offset
-#define BUFFERED_OFFSET_COND_CALL	0x0C	// Conditionally call a buffer with an offset
-#define BUFFERED_COPY			0x0D	// Copy blocks from multiple buffers into one buffer
-#define BUFFERED_CONSOLIDATE	0x0E	// Consolidate blocks inside a buffer into one
-#define BUFFERED_SPLIT			0x0F	// Split a buffer into multiple blocks
-#define BUFFERED_SPLIT_INTO		0x10	// Split a buffer into multiple blocks to new buffer(s)
-#define BUFFERED_SPLIT_FROM		0x11	// Split to new buffers from a target bufferId onwards
-#define BUFFERED_SPLIT_BY		0x12	// Split a buffer into multiple blocks by width (columns)
-#define BUFFERED_SPLIT_BY_INTO	0x13	// Split by width into new buffer(s)
-#define BUFFERED_SPLIT_BY_FROM	0x14	// Split by width to new buffers from a target bufferId onwards
-#define BUFFERED_SPREAD_INTO	0x15	// Spread blocks from a buffer to multiple target buffers
-#define BUFFERED_SPREAD_FROM	0x16	// Spread blocks from target buffer ID onwards
-#define BUFFERED_REVERSE_BLOCKS	0x17	// Reverse the order of blocks in a buffer
-#define BUFFERED_REVERSE		0x18	// Reverse the order of data in a buffer
-#define BUFFERED_COPY_REF		0x19	// Copy references to blocks from multiple buffers into one buffer
+#define BUFFERED_WRITE			        0x00	// Write to a numbered buffer
+#define BUFFERED_CALL			        0x01	// Call buffered commands
+#define BUFFERED_CLEAR			        0x02	// Clear buffered commands
+#define BUFFERED_CREATE			        0x03	// Create a new empty buffer
+#define BUFFERED_SET_OUTPUT		        0x04	// Set the output buffer
+#define BUFFERED_ADJUST			        0x05	// Adjust buffered commands
+#define BUFFERED_COND_CALL		        0x06	// Conditionally call a buffer
+#define BUFFERED_JUMP			        0x07	// Jump to a buffer
+#define BUFFERED_COND_JUMP		        0x08	// Conditionally jump to a buffer
+#define BUFFERED_OFFSET_JUMP	        0x09	// Jump to a buffer with an offset
+#define BUFFERED_OFFSET_COND_JUMP	    0x0A	// Conditionally jump to a buffer with an offset
+#define BUFFERED_OFFSET_CALL	        0x0B	// Call a buffer with an offset
+#define BUFFERED_OFFSET_COND_CALL	    0x0C	// Conditionally call a buffer with an offset
+#define BUFFERED_COPY			        0x0D	// Copy blocks from multiple buffers into one buffer
+#define BUFFERED_CONSOLIDATE	        0x0E	// Consolidate blocks inside a buffer into one
+#define BUFFERED_SPLIT			        0x0F	// Split a buffer into multiple blocks
+#define BUFFERED_SPLIT_INTO		        0x10	// Split a buffer into multiple blocks to new buffer(s)
+#define BUFFERED_SPLIT_FROM		        0x11	// Split to new buffers from a target bufferId onwards
+#define BUFFERED_SPLIT_BY		        0x12	// Split a buffer into multiple blocks by width (columns)
+#define BUFFERED_SPLIT_BY_INTO	        0x13	// Split by width into new buffer(s)
+#define BUFFERED_SPLIT_BY_FROM	        0x14	// Split by width to new buffers from a target bufferId onwards
+#define BUFFERED_SPREAD_INTO	        0x15	// Spread blocks from a buffer to multiple target buffers
+#define BUFFERED_SPREAD_FROM	        0x16	// Spread blocks from target buffer ID onwards
+#define BUFFERED_REVERSE_BLOCKS	        0x17	// Reverse the order of blocks in a buffer
+#define BUFFERED_REVERSE		        0x18	// Reverse the order of data in a buffer
+#define BUFFERED_COPY_REF		        0x19	// Copy references to blocks from multiple buffers into one buffer
+#define BUFFERED_COPY_AND_CONSOLIDATE   0x1A	// Copy blocks from multiple buffers into one buffer and consolidate them
 
-#define BUFFERED_DEBUG_INFO		0x20	// Get debug info about a buffer
+#define BUFFERED_DEBUG_INFO		        0x20	// Get debug info about a buffer
 
 // Adjust operation codes
 #define ADJUST_NOT				0x00	// Adjust: NOT

--- a/video/buffers.h
+++ b/video/buffers.h
@@ -83,11 +83,11 @@ std::shared_ptr<BufferStream> consolidateBuffers(std::vector<std::shared_ptr<Buf
 		// buffer couldn't be created
 		return nullptr;
 	}
-	auto offset = 0;
+	auto destination = bufferStream->getBuffer();
 	for (auto block : streams) {
 		auto bufferLength = block->size();
-		memcpy(bufferStream->getBuffer() + offset, block->getBuffer(), bufferLength);
-		offset += bufferLength;
+		memcpy(destination, block->getBuffer(), bufferLength);
+		destination += bufferLength;
 	}
 	return bufferStream;
 }

--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -1016,27 +1016,27 @@ void VDUStreamProcessor::bufferCopyAndConsolidate(uint16_t bufferId, std::vector
 	}
 
 	// work out total length of buffer
-    uint32_t length = 0;
+	uint32_t length = 0;
 	for (const auto sourceId : sourceBufferIds) {
 		if (sourceId != bufferId && buffers.find(sourceId) != buffers.end()) {
 			for (const auto &block : buffers[sourceId]) {
-                length += block->size();
-            }
-        }
-    }
+				length += block->size();
+			}
+		}
+	}
 
-    // Ensure the buffer has 1 block of the correct size
-    if (buffers[bufferId].size() != 1 || buffers[bufferId][0]->size() != length)
-    {
-    	buffers[bufferId].clear();
-        auto bufferStream = make_shared_psram<BufferStream>(length);
-        if (!bufferStream || !bufferStream->getBuffer()) {
-            // buffer couldn't be created
-            debug_log("bufferCopyAndConsolidate: failed to create buffer %d\n\r", bufferId);
-            return;
-        }
-        buffers[bufferId].push_back(bufferStream);
-    }
+	// Ensure the buffer has 1 block of the correct size
+	if (buffers[bufferId].size() != 1 || buffers[bufferId][0]->size() != length)
+	{
+		buffers[bufferId].clear();
+		auto bufferStream = make_shared_psram<BufferStream>(length);
+		if (!bufferStream || !bufferStream->getBuffer()) {
+			// buffer couldn't be created
+			debug_log("bufferCopyAndConsolidate: failed to create buffer %d\n\r", bufferId);
+			return;
+		}
+		buffers[bufferId].push_back(bufferStream);
+	}
 
 	auto destination = buffers[bufferId][0]->getBuffer();
 
@@ -1049,9 +1049,9 @@ void VDUStreamProcessor::bufferCopyAndConsolidate(uint16_t bufferId, std::vector
 			// loop thru blocks stored against this ID
 			for (const auto &block : buffers[sourceId]) {
 				// copy the block into our target buffer
-                auto bufferLength = block->size();
-                memcpy(destination, block->getBuffer(), bufferLength);
-                destination += bufferLength;
+				auto bufferLength = block->size();
+				memcpy(destination, block->getBuffer(), bufferLength);
+				destination += bufferLength;
 			}
 		} else {
 			debug_log("bufferCopyAndConsolidate: buffer %d not found\n\r", sourceId);

--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -166,6 +166,15 @@ void VDUStreamProcessor::vdu_sys_buffered() {
 			}
 			bufferCopyRef(bufferId, sourceBufferIds);
 		}	break;
+		case BUFFERED_COPY_AND_CONSOLIDATE: {
+			// read list of source buffer IDs
+			auto sourceBufferIds = getBufferIdsFromStream();
+			if (sourceBufferIds.size() == 0) {
+				debug_log("vdu_sys_buffered: no source buffer IDs\n\r");
+				return;
+			}
+			bufferCopyAndConsolidate(bufferId, sourceBufferIds);
+		}	break;
 		case BUFFERED_DEBUG_INFO: {
 			debug_log("vdu_sys_buffered: buffer %d, %d streams stored\n\r", bufferId, buffers[bufferId].size());
 			if (buffers[bufferId].size() == 0) {
@@ -991,6 +1000,64 @@ void VDUStreamProcessor::bufferCopyRef(uint16_t bufferId, std::vector<uint16_t> 
 		}
 	}
 	debug_log("bufferCopyRef: copied %d block references into buffer %d\n\r", buffers[bufferId].size(), bufferId);
+}
+
+// VDU 23, 0, &A0, bufferId; &1A, sourceBufferId; sourceBufferId; ...; 65535; : Copy blocks from buffers and consolidate
+// Copy (blocks from) a list of buffers into a new buffer and consolidate them
+// list is terminated with a bufferId of 65535 (-1)
+// Replaces the target buffer with the new one, but will re-use the memory if it is the same size
+// This is useful for constructing bitmaps from multiple buffers without needing an extra consolidate step
+// If target buffer is included in the source list it will be skipped.
+//
+void VDUStreamProcessor::bufferCopyAndConsolidate(uint16_t bufferId, std::vector<uint16_t> sourceBufferIds) {
+	if (bufferId == 65535) {
+		debug_log("bufferCopyAndConsolidate: ignoring buffer %d\n\r", bufferId);
+		return;
+	}
+
+	// work out total length of buffer
+    uint32_t length = 0;
+	for (const auto sourceId : sourceBufferIds) {
+		if (sourceId != bufferId && buffers.find(sourceId) != buffers.end()) {
+			for (const auto &block : buffers[sourceId]) {
+                length += block->size();
+            }
+        }
+    }
+
+    // Ensure the buffer has 1 block of the correct size
+    if (buffers[bufferId].size() != 1 || buffers[bufferId][0]->size() != length)
+    {
+    	buffers[bufferId].clear();
+        auto bufferStream = make_shared_psram<BufferStream>(length);
+        if (!bufferStream || !bufferStream->getBuffer()) {
+            // buffer couldn't be created
+            debug_log("bufferCopyAndConsolidate: failed to create buffer %d\n\r", bufferId);
+            return;
+        }
+        buffers[bufferId].push_back(bufferStream);
+    }
+
+	auto destination = buffers[bufferId][0]->getBuffer();
+
+	// loop thru buffer IDs
+	for (const auto sourceId : sourceBufferIds) {
+		if (sourceId == bufferId) {
+			debug_log("bufferCopyAndConsolidate: skipping buffer %d as it's the target\n\r", sourceId);
+		} else if (buffers.find(sourceId) != buffers.end()) {
+			// buffer ID exists
+			// loop thru blocks stored against this ID
+			for (const auto &block : buffers[sourceId]) {
+				// copy the block into our target buffer
+                auto bufferLength = block->size();
+                memcpy(destination, block->getBuffer(), bufferLength);
+                destination += bufferLength;
+			}
+		} else {
+			debug_log("bufferCopyAndConsolidate: buffer %d not found\n\r", sourceId);
+		}
+	}
+	debug_log("bufferCopyAndConsolidate: copied %d bytes into buffer %d\n\r", length, bufferId);
 }
 
 #endif // VDU_BUFFERED_H

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -95,6 +95,7 @@ class VDUStreamProcessor {
 		void bufferReverseBlocks(uint16_t bufferId);
 		void bufferReverse(uint16_t bufferId, uint8_t options);
 		void bufferCopyRef(uint16_t bufferId, std::vector<uint16_t> sourceBufferIds);
+		void bufferCopyAndConsolidate(uint16_t bufferId, std::vector<uint16_t> sourceBufferIds);
 
 		void vdu_sys_updater();
 		void unlock();


### PR DESCRIPTION
A new command that combines copy and consolidate into one.  The main advantage from a speed point of view is that it can reuse the buffer if it is the same size as the incoming data, so it doesn't need to remove and recreate it and can copy the source blocks directly in.
