### PR TITLE
updates to support all GCOL and PLOT “modes”

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@ board_build.f_cpu = 240000000L
 board_build.f_flash = 80000000L
 framework = arduino
 lib_deps =
-    https://github.com/AgonConsole8/vdp-gl.git#enhanced-plotting
+    https://github.com/AgonConsole8/vdp-gl.git#gcol-paint-modes
     fbiego/ESP32Time@^2.0.0
 build_flags =
     -DBOARD_HAS_PSRAM

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@ board_build.f_cpu = 240000000L
 board_build.f_flash = 80000000L
 framework = arduino
 lib_deps =
-    https://github.com/AgonConsole8/vdp-gl.git#copy-to-bitmap
+    https://github.com/AgonConsole8/vdp-gl.git#enhanced-plotting
     fbiego/ESP32Time@^2.0.0
 build_flags =
     -DBOARD_HAS_PSRAM

--- a/video/graphics.h
+++ b/video/graphics.h
@@ -244,7 +244,7 @@ void setGraphicsColour(uint8_t mode, uint8_t colour) {
 
 	uint8_t c = palette[colour % getVGAColourDepth()];
 
-	if (mode <= 6) {
+	if (mode <= 7) {
 		if (colour < 64) {
 			gfg = colourLookup[c];
 			debug_log("vdu_gcol: mode %d, gfg %d = %02X : %02X,%02X,%02X\n\r", mode, colour, c, gfg.R, gfg.G, gfg.B);

--- a/video/graphics.h
+++ b/video/graphics.h
@@ -270,12 +270,7 @@ void clearViewport(Rect * viewport) {
 		ttxt_instance.cls();
 	} else {
 		if (canvas) {
-			if (useViewports) {
-				canvas->fillRectangle(*viewport);
-			}
-			else {
-				canvas->clear();
-			}
+			canvas->fillRectangle(*viewport);
 		}
 	}
 }

--- a/video/graphics.h
+++ b/video/graphics.h
@@ -471,6 +471,7 @@ void plotCopyMove(uint8_t mode) {
 		// move rectangle needs to clear source rectangle
 		// being careful not to clear the destination rectangle
 		canvas->setBrushColor(gbg);
+		canvas->setPaintOptions(getPaintOptions(fabgl::PaintMode::Set, gpobg));
 		Rect sourceRect = Rect(sourceX, sourceY, sourceX + width, sourceY + height);
 		Rect destRect = Rect(x, y - height, x + width, y);
 		if (sourceRect.intersects(destRect)) {

--- a/video/graphics.h
+++ b/video/graphics.h
@@ -531,18 +531,19 @@ void plotCharacter(char c) {
 	} else {
 		bool isTextCursor = textCursorActive();
 		auto bitmap = getBitmapFromChar(c);
-		canvas->setClippingRect(isTextCursor ? defaultViewport : graphicsViewport);
+		if (isTextCursor) {
+			canvas->setClippingRect(defaultViewport);
+			canvas->setPenColor(tfg);
+			canvas->setBrushColor(tbg);
+			canvas->setPaintOptions(tpo);
+		} else {
+			canvas->setClippingRect(graphicsViewport);
+			canvas->setPenColor(gfg);
+			canvas->setPaintOptions(gpofg);
+		}
 		if (bitmap) {
 			canvas->drawBitmap(activeCursor->X, activeCursor->Y + fontH - bitmap->height, bitmap.get());
 		} else {
-			if (isTextCursor) {
-				canvas->setPenColor(tfg);
-				canvas->setBrushColor(tbg);
-				canvas->setPaintOptions(tpo);
-			} else {
-				canvas->setPenColor(gfg);
-				canvas->setPaintOptions(gpofg);
-			}
 			canvas->drawChar(activeCursor->X, activeCursor->Y, c);
 		}
 	}

--- a/video/graphics.h
+++ b/video/graphics.h
@@ -463,7 +463,7 @@ void plotCopyMove(uint8_t mode) {
 	uint16_t sourceX = p3.X < p2.X ? p3.X : p2.X;
 	uint16_t sourceY = p3.Y < p2.Y ? p3.Y : p2.Y;
 	uint16_t destX = p1.X;
-	uint16_t destY = (p1.Y ) - height;
+	uint16_t destY = p1.Y - height;
 
 	debug_log("plotCopyMove: mode %d, (%d,%d) -> (%d,%d), width: %d, height: %d\n\r", mode, sourceX, sourceY, destX, destY, width, height);
 	canvas->copyRect(sourceX, sourceY, destX, destY, width + 1, height + 1);
@@ -821,6 +821,7 @@ void scrollRegion(Rect * region, uint8_t direction, int16_t movement) {
 		if (direction == 3) ttxt_instance.scroll();
 	} else {
 		canvas->setPenColor(tbg);
+		canvas->setPaintOptions(tpo);
 		auto moveX = 0;
 		auto moveY = 0;
 		switch (direction) {

--- a/video/graphics.h
+++ b/video/graphics.h
@@ -383,12 +383,17 @@ void fillHorizontalLine(bool scanLeft, bool match, RGB888 matchColor) {
 	debug_log("fillHorizontalLine: (%d, %d) transformed to (%d,%d) -> (%d,%d)\n\r", p1.X, p1.Y, x1, y, x2, y);
 
 	if (x1 == x2 || x1 > x2) {
+		// Coordinate needs to be tweaked to match Acorn's behaviour
+		auto p = toCurrentCoordinates(scanLeft ? x2 + 1 : x2, y);
+		pushPoint(p.X, up1.Y);
 		// nothing to draw
 		return;
 	}
 	canvas->moveTo(x1, y);
 	canvas->lineTo(x2, y);
-	pushPoint(x2, y);
+
+	auto p = toCurrentCoordinates(x2, y);
+	pushPoint(p.X, up1.Y);
 }
 
 // Point point

--- a/video/graphics.h
+++ b/video/graphics.h
@@ -512,7 +512,14 @@ void plotCopyMove(uint8_t mode) {
 
 // Plot bitmap
 //
-void plotBitmap() {
+void plotBitmap(uint8_t mode) {
+	if ((mode & 0x03) == 0x03) {
+		// get a copy of gpobg, without changing it's paint mode
+		auto paintOptions = getPaintOptions(gpobg.mode, gpobg);
+		// swapFGBG on bitmap plots indicates to plot using pen color instead of bitmap
+		paintOptions.swapFGBG = true;
+		canvas->setPaintOptions(paintOptions);
+	}
 	drawBitmap(p1.X, p1.Y, true);
 }
 

--- a/video/graphics.h
+++ b/video/graphics.h
@@ -162,19 +162,25 @@ uint8_t getPaletteIndex(RGB888 colour) {
 void setPalette(uint8_t l, uint8_t p, uint8_t r, uint8_t g, uint8_t b) {
 	RGB888 col;				// The colour to set
 
-	if (getVGAColourDepth() < 64) {		// If it is a paletted video mode
-		if (p == 255) {					// If p = 255, then use the RGB values
-			col = RGB888(r, g, b);
-		} else if (p < 64) {			// If p < 64, then look the value up in the colour lookup table
-			col = colourLookup[p];
-		} else {
-			debug_log("vdu_palette: p=%d not supported\n\r", p);
-			return;
-		}
-		setPaletteItem(l, col);
-		debug_log("vdu_palette: %d,%d,%d,%d,%d\n\r", l, p, r, g, b);
+	if (p == 255) {					// If p = 255, then use the RGB values
+		col = RGB888(r, g, b);
+	} else if (p < 64) {			// If p < 64, then look the value up in the colour lookup table
+		col = colourLookup[p];
 	} else {
-		debug_log("vdu_palette: not supported in this mode\n\r");
+		debug_log("vdu_palette: p=%d not supported\n\r", p);
+		return;
+	}
+
+	debug_log("vdu_palette: %d,%d,%d,%d,%d\n\r", l, p, r, g, b);
+	if (getVGAColourDepth() < 64) {		// If it is a paletted video mode
+		setPaletteItem(l, col);
+	} else {
+		// adjust our palette array for new colour
+		// palette is an index into the colourLookup table, and our index is in 00RRGGBB format
+		uint8_t index = (col.R >> 6) << 4 | (col.G >> 6) << 2 | (col.B >> 6);
+		auto lookedup = colourLookup[index];
+		debug_log("vdu_palette: col.R %02X, col.G %02X, col.B %02X, index %d (%02X), lookup %02X, %02X, %02X\n\r", col.R, col.G, col.B, index, index, lookedup.R, lookedup.G, lookedup.B);
+		palette[l] = index;
 	}
 }
 

--- a/video/graphics.h
+++ b/video/graphics.h
@@ -17,7 +17,8 @@ fabgl::PaintOptions			gpo;				// Graphics paint options
 fabgl::PaintOptions			tpo;				// Text paint options
 
 Point			p1, p2, p3;						// Coordinate store for plot
-Point			rp1, rp2, rp3;					// Relative coordinates store for plot
+Point			rp1;							// Relative coordinates store for plot
+Point			up1;							// Unscaled coordinates store for plot
 RGB888			gfg, gbg;						// Graphics foreground and background colour
 RGB888			tfg, tbg;						// Text foreground and background colour
 uint8_t			fontW;							// Font width
@@ -280,19 +281,17 @@ void clearViewport(Rect * viewport) {
 // Push point to list
 //
 void pushPoint(Point p) {
-	rp3 = rp2;
-	rp2 = rp1;
 	rp1 = Point(p.X - p1.X, p.Y - p1.Y);
 	p3 = p2;
 	p2 = p1;
 	p1 = p;
 }
 void pushPoint(uint16_t x, uint16_t y) {
+	up1 = Point(x, y);
 	pushPoint(translateCanvas(scale(x, y)));
 }
 void pushPointRelative(int16_t x, int16_t y) {
-	auto scaledPoint = scale(x, y);
-	pushPoint(Point(p1.X + scaledPoint.X, p1.Y + (logicalCoords ? -scaledPoint.Y : scaledPoint.Y)));
+	pushPoint(up1.X + x, up1.Y + y);
 }
 
 // get graphics cursor

--- a/video/graphics.h
+++ b/video/graphics.h
@@ -390,10 +390,20 @@ void plotLine(bool omitFirstPoint = false, bool omitLastPoint = false) {
 	RGB888 firstPixelColour;
 	RGB888 lastPixelColour;
 	if (omitFirstPoint) {
-		firstPixelColour = canvas->getPixel(p2.X, p2.Y);
+		if (p2.X >= 0 && p2.X < canvasW && p2.Y >= 0 && p2.Y < canvasH) {
+			canvas->waitCompletion(false);
+			firstPixelColour = canvas->getPixel(p2.X, p2.Y);
+		} else {
+			omitFirstPoint = false;
+		}
 	}
 	if (omitLastPoint) {
-		lastPixelColour = canvas->getPixel(p1.X, p1.Y);
+		if (p1.X >= 0 && p1.X < canvasW && p1.Y >= 0 && p1.Y < canvasH) {
+			canvas->waitCompletion(false);
+			lastPixelColour = canvas->getPixel(p1.X, p1.Y);
+		} else {
+			omitLastPoint = false;
+		}
 	}
 	canvas->lineTo(p1.X, p1.Y);
 	if (omitFirstPoint) {

--- a/video/graphics.h
+++ b/video/graphics.h
@@ -458,50 +458,61 @@ void plotCircle(bool filled = false) {
 // Copy or move a rectangle
 //
 void plotCopyMove(uint8_t mode) {
-	uint16_t x = p1.X;
-	uint16_t y = p1.Y;
-	uint16_t width = abs(p3.X - p2.X) + 1;
-	uint16_t height = abs(p3.Y - p2.Y) + 1;
+	uint16_t width = abs(p3.X - p2.X);
+	uint16_t height = abs(p3.Y - p2.Y);
 	uint16_t sourceX = p3.X < p2.X ? p3.X : p2.X;
 	uint16_t sourceY = p3.Y < p2.Y ? p3.Y : p2.Y;
+	uint16_t destX = p1.X;
+	uint16_t destY = (p1.Y ) - height;
 
-	debug_log("plotCopyMove: mode %d, (%d,%d) -> (%d,%d), width: %d, height: %d\n\r", mode, sourceX, sourceY, x, y, width, height);
-	canvas->copyRect(sourceX, sourceY, x, y - height, width, height);
+	debug_log("plotCopyMove: mode %d, (%d,%d) -> (%d,%d), width: %d, height: %d\n\r", mode, sourceX, sourceY, destX, destY, width, height);
+	canvas->copyRect(sourceX, sourceY, destX, destY, width + 1, height + 1);
 	if (mode == 1 || mode == 5) {
 		// move rectangle needs to clear source rectangle
 		// being careful not to clear the destination rectangle
 		canvas->setBrushColor(gbg);
 		canvas->setPaintOptions(getPaintOptions(fabgl::PaintMode::Set, gpobg));
 		Rect sourceRect = Rect(sourceX, sourceY, sourceX + width, sourceY + height);
-		Rect destRect = Rect(x, y - height, x + width, y);
+		debug_log("plotCopyMove: source rectangle (%d,%d) -> (%d,%d)\n\r", sourceRect.X1, sourceRect.Y1, sourceRect.X2, sourceRect.Y2);
+		Rect destRect = Rect(destX, destY, destX + width, destY + height);
+		debug_log("plotCopyMove: destination rectangle (%d,%d) -> (%d,%d)\n\r", destRect.X1, destRect.Y1, destRect.X2, destRect.Y2);
 		if (sourceRect.intersects(destRect)) {
 			// we can use clipping rects to block out parts of the screen
 			// the areas above, below, left, and right of the destination rectangle
 			// and then draw rectangles over our source rectangle
 			auto intersection = sourceRect.intersection(destRect);
+			debug_log("intersection: (%d,%d) -> (%d,%d)\n\r", intersection.X1, intersection.Y1, intersection.X2, intersection.Y2);
 
 			if (intersection.X1 > sourceRect.X1) {
 				// fill in source area to the left of destination
 				debug_log("clearing left of destination\n\r");
-				canvas->setClippingRect(Rect(sourceRect.X1, sourceRect.Y1, intersection.X1 - 1, sourceRect.Y2));
+				auto clearClip = Rect(sourceRect.X1, sourceRect.Y1, intersection.X1 - 1, sourceRect.Y2);
+				debug_log("clearClip: (%d,%d) -> (%d,%d)\n\r", clearClip.X1, clearClip.Y1, clearClip.X2, clearClip.Y2);
+				canvas->setClippingRect(clearClip);
 				canvas->fillRectangle(sourceRect);
 			}
 			if (intersection.X2 < sourceRect.X2) {
 				// fill in source area to the right of destination
 				debug_log("clearing right of destination\n\r");
-				canvas->setClippingRect(Rect(intersection.X2, sourceRect.Y1, sourceRect.X2, sourceRect.Y2));
+				auto clearClip = Rect(intersection.X2 + 1, sourceRect.Y1, sourceRect.X2, sourceRect.Y2);
+				debug_log("clearClip: (%d,%d) -> (%d,%d)\n\r", clearClip.X1, clearClip.Y1, clearClip.X2, clearClip.Y2);
+				canvas->setClippingRect(clearClip);
 				canvas->fillRectangle(sourceRect);
 			}
 			if (intersection.Y1 > sourceRect.Y1) {
 				// fill in source area above destination
 				debug_log("clearing above destination\n\r");
-				canvas->setClippingRect(Rect(sourceRect.X1, sourceRect.Y1, sourceRect.X2, intersection.Y1 - 1));
+				auto clearClip = Rect(sourceRect.X1, sourceRect.Y1, sourceRect.X2, intersection.Y1 - 1);
+				debug_log("clearClip: (%d,%d) -> (%d,%d)\n\r", clearClip.X1, clearClip.Y1, clearClip.X2, clearClip.Y2);
+				canvas->setClippingRect(clearClip);
 				canvas->fillRectangle(sourceRect);
 			}
 			if (intersection.Y2 < sourceRect.Y2) {
 				// fill in source area below destination
 				debug_log("clearing below destination\n\r");
-				canvas->setClippingRect(Rect(sourceRect.X1, intersection.Y2, sourceRect.X2, sourceRect.Y2));
+				auto clearClip = Rect(sourceRect.X1, intersection.Y2 + 1, sourceRect.X2, sourceRect.Y2);
+				debug_log("clearClip: (%d,%d) -> (%d,%d)\n\r", clearClip.X1, clearClip.Y1, clearClip.X2, clearClip.Y2);
+				canvas->setClippingRect(clearClip);
 				canvas->fillRectangle(sourceRect);
 			}
 		} else {

--- a/video/sprites.h
+++ b/video/sprites.h
@@ -28,6 +28,9 @@ uint16_t		mCursor = MOUSE_DEFAULT_CURSOR;	// Mouse cursor
 // character to bitmap mapping
 std::vector<uint16_t> charToBitmap(255, 65535);
 
+extern fabgl::PaintOptions			gpofg;
+extern fabgl::PaintOptions getPaintOptions(fabgl::PaintMode mode, fabgl::PaintOptions priorPaintOptions);
+
 std::shared_ptr<Bitmap> getBitmap(uint16_t id = currentBitmap) {
 	if (bitmaps.find(id) != bitmaps.end()) {
 		return bitmaps[id];
@@ -61,9 +64,13 @@ inline uint16_t getCurrentBitmapId() {
 	return currentBitmap;
 }
 
-void drawBitmap(uint16_t x, uint16_t y, bool compensateHeight = false) {
+void drawBitmap(uint16_t x, uint16_t y, bool compensateHeight, bool forceSet = false) {
 	auto bitmap = getBitmap();
 	if (bitmap) {
+		if (forceSet) {
+			auto options = getPaintOptions(fabgl::PaintMode::Set, gpofg);
+			canvas->setPaintOptions(options);
+		}
 		canvas->drawBitmap(x, (compensateHeight && logicalCoords) ? y - bitmap->height : y, bitmap.get());
 	} else {
 		debug_log("drawBitmap: bitmap %d not found\n\r", currentBitmap);

--- a/video/sprites.h
+++ b/video/sprites.h
@@ -290,4 +290,11 @@ void resetSprites() {
 	// }
 }
 
+void setSpritePaintMode(uint8_t mode) {
+	auto sprite = getSprite();
+	if (mode <= 7) {
+		sprite->paintOptions.mode = static_cast<fabgl::PaintMode>(mode);
+	}
+}
+
 #endif // SPRITES_H

--- a/video/sprites.h
+++ b/video/sprites.h
@@ -71,7 +71,7 @@ void drawBitmap(uint16_t x, uint16_t y, bool compensateHeight, bool forceSet = f
 			auto options = getPaintOptions(fabgl::PaintMode::Set, gpofg);
 			canvas->setPaintOptions(options);
 		}
-		canvas->drawBitmap(x, (compensateHeight && logicalCoords) ? y - bitmap->height : y, bitmap.get());
+		canvas->drawBitmap(x, (compensateHeight && logicalCoords) ? (y + 1 - bitmap->height) : y, bitmap.get());
 	} else {
 		debug_log("drawBitmap: bitmap %d not found\n\r", currentBitmap);
 	}

--- a/video/vdu.h
+++ b/video/vdu.h
@@ -327,7 +327,7 @@ void VDUStreamProcessor::vdu_plot() {
 				debug_log("plot ellipse not implemented\n\r");
 				break;
 			case 0xE8:	// Bitmap plot
-				plotBitmap();
+				plotBitmap(mode);
 				break;
 		}
 

--- a/video/vdu.h
+++ b/video/vdu.h
@@ -251,104 +251,88 @@ void VDUStreamProcessor::vdu_plot() {
 	}
 	setGraphicsOptions(mode);
 
-	// make copy/move work for mode 2 and 6
-	if (operation == 0xB8 && (mode == 2 || mode == 6)) {
-		mode = 3;
-	}
-
 	debug_log("vdu_plot: operation: %X, mode %d, (%d,%d) -> (%d,%d)\n\r", operation, mode, x, y, p1.X, p1.Y);
 
-	switch (mode) {
-		case 0:
-		case 4:
-			// move to modes
-			moveTo();
-			break;
-		case 2:
-		case 6:
-			// draw inverse logical colour not supported
-			debug_log("plot inverse logical colour not implemented\n\r");
-			break;
-		default:
-			// 1, 3, 5, 7 are all draw modes
-			switch (operation) {
-				case 0x00:	// line
-					plotLine();
-					break;
-				case 0x08:	// line, omitting last point
-					plotLine(false, true);
-					break;
-				case 0x10:	// dot-dash line
-				case 0x18:	// dot-dash line, omitting first point
-				case 0x30:	// dot-dash line, omitting first, pattern continued
-				case 0x38:	// dot-dash line, omitting both, pattern continued
-					debug_log("plot dot-dash line not implemented\n\r");
-					break;
-				case 0x20:	// solid line, first point omitted
-					plotLine(true, false);
-					break;
-				case 0x28:	// solid line, first and last points omitted
-					plotLine(true, true);
-					break;
-				case 0x40:	// point
-					plotPoint();
-					break;
-				case 0x48:	// line fill left/right to non-bg
-					fillHorizontalLine(true, false, gbg);
-					break;
-				case 0x50:	// triangle fill
-					setGraphicsFill(mode);
-					plotTriangle();
-					break;
-				case 0x58:	// line fill right to bg
-					fillHorizontalLine(false, true, gbg);
-					break;
-				case 0x60:	// rectangle fill
-					setGraphicsFill(mode);
-					plotRectangle();
-					break;
-				case 0x68:	// line fill left/left to fg
-					fillHorizontalLine(true, true, gfg);
-					break;
-				case 0x70:	// parallelogram fill
-					setGraphicsFill(mode);
-					plotParallelogram();
-					break;
-				case 0x78:	// line fill right to non-fg
-					fillHorizontalLine(false, false, gfg);
-					break;
-				case 0x80:	// flood to non-bg
-				case 0x88:	// flood to fg
-					debug_log("plot flood fill not implemented\n\r");
-					break;
-				case 0x90:	// circle outline
-					plotCircle();
-					break;
-				case 0x98:	// circle fill
-					setGraphicsFill(mode);
-					plotCircle(true);
-					break;
-				case 0xA0:	// circular arc
-				case 0xA8:	// circular segment
-				case 0xB0:	// circular sector
-					// fab-gl has no arc or segment operations, only simple ellipse (squashable circle)
-					debug_log("plot circular arc/segment/sector not implemented\n\r");
-					break;
-				case 0xB8:	// copy/move
-					plotCopyMove(mode);
-					break;
-				case 0xC0:	// ellipse outline
-				case 0xC8:	// ellipse fill
-					// fab-gl's ellipse isn't compatible with BBC BASIC
-					debug_log("plot ellipse not implemented\n\r");
-					break;
-				case 0xE8:	// Bitmap plot
-					plotBitmap();
-					break;
-			}
-			moveTo();
-			break;
+	// if (mode != 0 && mode != 4) {
+	if (mode & 0x03) {
+		switch (operation) {
+			case 0x00:	// line
+				plotLine();
+				break;
+			case 0x08:	// line, omitting last point
+				plotLine(false, true);
+				break;
+			case 0x10:	// dot-dash line
+			case 0x18:	// dot-dash line, omitting first point
+			case 0x30:	// dot-dash line, omitting first, pattern continued
+			case 0x38:	// dot-dash line, omitting both, pattern continued
+				debug_log("plot dot-dash line not implemented\n\r");
+				break;
+			case 0x20:	// solid line, first point omitted
+				plotLine(true, false);
+				break;
+			case 0x28:	// solid line, first and last points omitted
+				plotLine(true, true);
+				break;
+			case 0x40:	// point
+				plotPoint();
+				break;
+			case 0x48:	// line fill left/right to non-bg
+				fillHorizontalLine(true, false, gbg);
+				break;
+			case 0x50:	// triangle fill
+				setGraphicsFill(mode);
+				plotTriangle();
+				break;
+			case 0x58:	// line fill right to bg
+				fillHorizontalLine(false, true, gbg);
+				break;
+			case 0x60:	// rectangle fill
+				setGraphicsFill(mode);
+				plotRectangle();
+				break;
+			case 0x68:	// line fill left/left to fg
+				fillHorizontalLine(true, true, gfg);
+				break;
+			case 0x70:	// parallelogram fill
+				setGraphicsFill(mode);
+				plotParallelogram();
+				break;
+			case 0x78:	// line fill right to non-fg
+				fillHorizontalLine(false, false, gfg);
+				break;
+			case 0x80:	// flood to non-bg
+			case 0x88:	// flood to fg
+				debug_log("plot flood fill not implemented\n\r");
+				break;
+			case 0x90:	// circle outline
+				plotCircle();
+				break;
+			case 0x98:	// circle fill
+				setGraphicsFill(mode);
+				plotCircle(true);
+				break;
+			case 0xA0:	// circular arc
+			case 0xA8:	// circular segment
+			case 0xB0:	// circular sector
+				// fab-gl has no arc or segment operations, only simple ellipse (squashable circle)
+				debug_log("plot circular arc/segment/sector not implemented\n\r");
+				break;
+			case 0xB8:	// copy/move
+				plotCopyMove(mode);
+				break;
+			case 0xC0:	// ellipse outline
+			case 0xC8:	// ellipse fill
+				// fab-gl's ellipse isn't compatible with BBC BASIC
+				debug_log("plot ellipse not implemented\n\r");
+				break;
+			case 0xE8:	// Bitmap plot
+				plotBitmap();
+				break;
+		}
+
 	}
+	moveTo();
 }
 
 // VDU 26 Reset graphics and text viewports

--- a/video/vdu_sprites.h
+++ b/video/vdu_sprites.h
@@ -248,7 +248,7 @@ void VDUStreamProcessor::createBitmapFromScreen(uint16_t bufferId) {
 		debug_log("vdu_sys_sprites: failed to create buffer\n\r");
 		return;
 	}
-	createBitmapFromBuffer(bufferId, 3, width, height);
+	createBitmapFromBuffer(bufferId, 1, width, height);
 	// Copy screen area to buffer
 	canvas->copyToBitmap(x1, y1, getBitmap(bufferId).get());
 }

--- a/video/vdu_sprites.h
+++ b/video/vdu_sprites.h
@@ -156,6 +156,12 @@ void VDUStreamProcessor::vdu_sys_sprites() {
 			debug_log("vdu_sys_sprites: reset sprites\n\r");
 		}	break;
 
+		case 18: {	// Set sprite paint mode
+			auto b = readByte_t(); if (b == -1) return;
+			debug_log("vdu_sys_sprites: set paint sprite mode %d\n\r", b);
+			setSpritePaintMode(b);
+		}	break;
+
 		// Extended bitmap commands
 		case 0x20: {	// Select bitmap, 16-bit buffer ID
 			auto b = readWord_t(); if (b == -1) return;

--- a/video/vdu_sprites.h
+++ b/video/vdu_sprites.h
@@ -224,10 +224,12 @@ void VDUStreamProcessor::createBitmapFromScreen(uint16_t bufferId) {
 		width = -width;
 		x1 = x2;
 	}
+	width += 1;
 	if (height < 0) {
 		height = -height;
 		y1 = y2;
 	}
+	height += 1;
 	auto size = width * height;
 	if (size == 0) {
 		debug_log("vdu_sys_sprites: bitmap %d - zero size\n\r", bufferId);

--- a/video/vdu_sprites.h
+++ b/video/vdu_sprites.h
@@ -60,7 +60,7 @@ void VDUStreamProcessor::vdu_sys_sprites() {
 			auto rx = readWord_t(); if (rx == -1) return;
 			auto ry = readWord_t(); if (ry == -1) return;
 
-			drawBitmap(rx,ry);
+			drawBitmap(rx,ry, false, true);
 			debug_log("vdu_sys_sprites: bitmap %d draw command\n\r", getCurrentBitmapId());
 		}	break;
 


### PR DESCRIPTION
supports all of Acorn's "basic" GCOL modes, 0-7 (0-4 from the Beeb, 5-7 from the Archimedes)

also support the "invert pixels" PLOT "mode", which operates the same as GCOL mode 4

- [x] Use different modes for fg and bg colour plotting operations (as per Acorn)
- [x] Ensure that CLG is consistent with Acorn
- [x] Support current (fg) mode for text plotting when in VDU 5 mode
- [x] Bitmap plots??