### PR TITLE
add command to allow control keys to be disabled

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -51,6 +51,7 @@
 #define VDP_UDG_RESET			0x91	// Reset UDGs
 #define VDP_MAP_CHAR_TO_BITMAP	0x92	// Map a character to a bitmap
 #define VDP_READ_COLOUR			0x94	// Read colour
+#define VDP_CONTROLKEYS			0x98	// Control keys on/off
 #define VDP_BUFFERED			0xA0	// Buffered commands
 #define VDP_UPDATER				0xA1	// Update VDP
 #define VDP_LOGICALCOORDS		0xC0	// Switch BBC Micro style logical coords on and off

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -169,6 +169,12 @@ void VDUStreamProcessor::vdu_sys_video() {
 				sendColour(index);
 			}
 		}	break;
+		case VDP_CONTROLKEYS: {			// VDU 23, 0, &98, n
+			auto b = readByte_t();		// Set control keys,  0 = off, 1 = on (default)
+			if (b >= 0) {
+				controlKeys = (bool) b;
+			}
+		}	break;
 		case VDP_BUFFERED: {			// VDU 23, 0, &A0, bufferId; command, <args>
 			vdu_sys_buffered();
 		}	break;

--- a/video/video.ino
+++ b/video/video.ino
@@ -59,6 +59,7 @@ HardwareSerial	DBGSerial(0);
 TerminalState	terminalState = TerminalState::Disabled;		// Terminal state (for CP/M, etc)
 bool			consoleMode = false;			// Serial console mode (0 = off, 1 = console enabled)
 bool			printerOn = false;				// Output "printer" to debug serial link
+bool			controlKeys = true;				// Control keys enabled
 
 #include "version.h"							// Version information
 #include "agon_ps2.h"							// Keyboard support
@@ -132,7 +133,7 @@ void do_keyboard() {
 	if (getKeyboardKey(&keycode, &modifiers, &vk, &down)) {
 		// Handle some control keys
 		//
-		if (down) {
+		if (controlKeys && down) {
 			switch (keycode) {
 				case 2:		// printer on
 				case 3:		// printer off


### PR DESCRIPTION
and re-enabled again :D

`VDU 23,0 &98,n` sets whether control keys are functional, where 0 = off and 1 = on (default)

Fixes #145 