### PR TITLE
Plot command data read in one go

### DIFF
--- a/video/vdu.h
+++ b/video/vdu.h
@@ -238,15 +238,14 @@ void VDUStreamProcessor::vdu_graphicsViewport() {
 void VDUStreamProcessor::vdu_plot() {
 	uint8_t buffer[5];
 	auto remaining = readIntoBuffer(buffer, 5);
-	if (remaining > 0) return; // Timeout
+	if (remaining > 0 || ttxtMode) return; // Timeout or teletext mode active
 
 	auto& command = buffer[0];
 	auto mode = command & 0x07;
 	auto operation = command & 0xF8;
 
-	auto x = *(short*)(buffer+1);
-	auto y = *(short*)(buffer+3);
-	if (ttxtMode) return;
+	auto& x = *(short*)(buffer+1);
+	auto& y = *(short*)(buffer+3);
 
 	if (mode < 4) {
 		pushPointRelative(x, y);

--- a/video/vdu.h
+++ b/video/vdu.h
@@ -236,12 +236,16 @@ void VDUStreamProcessor::vdu_graphicsViewport() {
 // VDU 25 Handle PLOT
 //
 void VDUStreamProcessor::vdu_plot() {
-	auto command = readByte_t(); if (command == -1) return;
+	uint8_t buffer[5];
+	auto remaining = readIntoBuffer(buffer, 5);
+	if (remaining > 0) return; // Timeout
+
+	auto& command = buffer[0];
 	auto mode = command & 0x07;
 	auto operation = command & 0xF8;
 
-	auto x = readWord_t(); if (x == -1) return; else x = (short)x;
-	auto y = readWord_t(); if (y == -1) return; else y = (short)y;
+	auto x = *(short*)(buffer+1);
+	auto y = *(short*)(buffer+3);
 	if (ttxtMode) return;
 
 	if (mode < 4) {


### PR DESCRIPTION
The 5 bytes of data following a plot command (VDU 25) are now read in in one go instead of reading 1 byte and 2 words.
In my test-bed where I'm plotting a lot of triangles (in a strip formation), this improves the number of triangles I can render at 30FPS from 232 to 250 (An 7.75% improvement in speed)