### PR TITLE
update PLOT to support dotted lines

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,10 +19,13 @@ board_build.f_cpu = 240000000L
 board_build.f_flash = 80000000L
 framework = arduino
 lib_deps =
-    https://github.com/AgonConsole8/vdp-gl.git#gcol-paint-modes
+    https://github.com/AgonConsole8/vdp-gl.git#dotted-lines
+    ; ../vdp-gl
     fbiego/ESP32Time@^2.0.0
 build_flags =
     -DBOARD_HAS_PSRAM
     -mfix-esp32-psram-cache-issue
+; build_type = debug
+monitor_filters = esp32_exception_decoder
 monitor_speed = 115200
 upload_speed = 600000

--- a/video/agon.h
+++ b/video/agon.h
@@ -57,6 +57,7 @@
 #define VDP_LOGICALCOORDS		0xC0	// Switch BBC Micro style logical coords on and off
 #define VDP_LEGACYMODES			0xC1	// Switch VDP 1.03 compatible modes on and off
 #define VDP_SWITCHBUFFER		0xC3	// Double buffering control
+#define VDP_PATTERN_LENGTH		0xF2	// Set pattern length (*FX 163,242,n)
 #define VDP_CONSOLEMODE			0xFE	// Switch console mode on and off
 #define VDP_TERMINALMODE		0xFF	// Switch to terminal mode
 

--- a/video/graphics.h
+++ b/video/graphics.h
@@ -386,36 +386,17 @@ void moveTo() {
 
 // Line plot
 //
-void plotLine(bool omitFirstPoint = false, bool omitLastPoint = false) {
-	RGB888 firstPixelColour;
-	RGB888 lastPixelColour;
-	if (omitFirstPoint) {
-		if (p2.X >= 0 && p2.X < canvasW && p2.Y >= 0 && p2.Y < canvasH) {
-			canvas->waitCompletion(false);
-			firstPixelColour = canvas->getPixel(p2.X, p2.Y);
-		} else {
-			omitFirstPoint = false;
-		}
+void plotLine(bool omitFirstPoint = false, bool omitLastPoint = false, bool usePattern = false, bool resetPattern = true) {
+	auto lineOptions = fabgl::LineOptions();
+	lineOptions.omitFirst = omitFirstPoint;
+	lineOptions.omitLast = omitLastPoint;
+	lineOptions.usePattern = usePattern;
+	if (resetPattern) {
+		canvas->setLinePatternOffset(0);
 	}
-	if (omitLastPoint) {
-		if (p1.X >= 0 && p1.X < canvasW && p1.Y >= 0 && p1.Y < canvasH) {
-			canvas->waitCompletion(false);
-			lastPixelColour = canvas->getPixel(p1.X, p1.Y);
-		} else {
-			omitLastPoint = false;
-		}
-	}
+	canvas->setLineOptions(lineOptions);
+
 	canvas->lineTo(p1.X, p1.Y);
-	if (omitFirstPoint) {
-		auto paintOptions = getPaintOptions(fabgl::PaintMode::Set, gpofg);
-		canvas->setPaintOptions(paintOptions);
-		canvas->setPixel(p2, firstPixelColour);
-	}
-	if (omitLastPoint) {
-		auto paintOptions = getPaintOptions(fabgl::PaintMode::Set, gpofg);
-		canvas->setPaintOptions(paintOptions);
-		canvas->setPixel(p1, lastPixelColour);
-	}
 }
 
 // Fill horizontal line
@@ -903,6 +884,23 @@ void scrollRegion(Rect * region, uint8_t direction, int16_t movement) {
 
 void setLineThickness(uint8_t thickness) {
 	canvas->setPenWidth(thickness);
+}
+
+void setDottedLinePattern(uint8_t pattern[8]) {
+	auto linePattern = fabgl::LinePattern();
+	linePattern.setPattern(pattern);
+	canvas->setLinePattern(linePattern);
+}
+
+void setDottedLinePatternLength(uint8_t length) {
+	if (length == 0) {
+		// reset the line pattern
+		auto linePattern = fabgl::LinePattern();
+		canvas->setLinePattern(linePattern);
+		canvas->setLinePatternLength(8);
+		return;
+	}
+	canvas->setLinePatternLength(length);
 }
 
 #endif

--- a/video/vdu.h
+++ b/video/vdu.h
@@ -263,10 +263,16 @@ void VDUStreamProcessor::vdu_plot() {
 				plotLine(false, true);
 				break;
 			case 0x10:	// dot-dash line
+				plotLine(false, false, true);
+				break;
 			case 0x18:	// dot-dash line, omitting first point
+				plotLine(true, false, true);
+				break;
 			case 0x30:	// dot-dash line, omitting first, pattern continued
+				plotLine(true, false, true, false);
+				break;
 			case 0x38:	// dot-dash line, omitting both, pattern continued
-				debug_log("plot dot-dash line not implemented\n\r");
+				plotLine(true, true, true, false);
 				break;
 			case 0x20:	// solid line, first point omitted
 				plotLine(true, false);

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -82,6 +82,13 @@ void VDUStreamProcessor::vdu_sys() {
 					enableCursor((bool) b);
 				}
 			}	break;
+			case 0x06: {					// VDU 23, 6
+				uint8_t pattern[8];			// Set dotted line pattern
+				auto remaining = readIntoBuffer(pattern, 8);
+				if (remaining == 0) {
+					setDottedLinePattern(pattern);
+				}
+			}	break;
 			case 0x07: {					// VDU 23, 7
 				vdu_sys_scroll();			// Scroll
 			}	break;
@@ -201,6 +208,12 @@ void VDUStreamProcessor::vdu_sys_video() {
 		}	break;
 		case VDP_SWITCHBUFFER: {		// VDU 23, 0, &C3
 			switchBuffer();
+		}	break;
+		case VDP_PATTERN_LENGTH: {		// VDU 23, 0, &F2, n
+			auto b = readByte_t();		// Set pattern length
+			if (b >= 0) {
+				setDottedLinePatternLength(b);
+			}
 		}	break;
 		case VDP_CONSOLEMODE: {			// VDU 23, 0, &FE, n
 			auto b = readByte_t();


### PR DESCRIPTION
enables all the dotted line PLOT codes

adds support for `VDU 23,6,n1,n2,n3,n4,n5,n6,n7.n8` to set the dotted line pattern

adds `VDU 23,0,242,n` (or `VDU 23,0,&F2,n`) to set the pattern length.  setting a length of zero will reset to default pattern, and length of 8
