### PR TITLE
improve performance

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -23,7 +23,7 @@ lib_deps =
     fbiego/ESP32Time@^2.0.0
 build_unflags = -Os
 build_flags =
-    -O3
+    -O2
     -DBOARD_HAS_PSRAM
     -mfix-esp32-psram-cache-issue
 ; build_type = debug

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,8 +21,12 @@ framework = arduino
 lib_deps =
     https://github.com/AgonConsole8/vdp-gl.git#gcol-paint-modes
     fbiego/ESP32Time@^2.0.0
+build_unflags = -Os
 build_flags =
+    -O3
     -DBOARD_HAS_PSRAM
     -mfix-esp32-psram-cache-issue
+; build_type = debug
+monitor_filters = esp32_exception_decoder
 monitor_speed = 115200
 upload_speed = 600000

--- a/video/vdp_protocol.h
+++ b/video/vdp_protocol.h
@@ -22,6 +22,7 @@ void setupVDPProtocol() {
 	VDPSerial.begin(UART_BR, SERIAL_8N1, UART_RX, UART_TX);
 	VDPSerial.setHwFlowCtrlMode(HW_FLOWCTRL_RTS, 64);			// Can be called whenever
 	VDPSerial.setPins(UART_NA, UART_NA, UART_CTS, UART_RTS);	// Must be called after begin
+	VDPSerial.setTimeout(COMMS_TIMEOUT);
 }
 
 // TODO remove the following - it's only here for cursor.h to send escape key when doing paged mode handling

--- a/video/vdu.h
+++ b/video/vdu.h
@@ -240,8 +240,8 @@ void VDUStreamProcessor::vdu_plot() {
 	auto mode = command & 0x07;
 	auto operation = command & 0xF8;
 
-	auto x = readWord_t(); if (x == -1) return; else x = (short)x;
-	auto y = readWord_t(); if (y == -1) return; else y = (short)y;
+	auto x = readWord_t(); if (x == -1) return; else x = (int16_t)x;
+	auto y = readWord_t(); if (y == -1) return; else y = (int16_t)y;
 	if (ttxtMode) return;
 
 	if (mode < 4) {

--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -16,8 +16,8 @@
 // VDU 23, 0, &A0, bufferId; command: Buffered command support
 //
 void VDUStreamProcessor::vdu_sys_buffered() {
-	auto bufferId = readWord_t();
-	auto command = readByte_t();
+	auto bufferId = readWord_t(); if (bufferId == -1) return;
+	auto command = readByte_t(); if (command == -1) return;
 
 	switch (command) {
 		case BUFFERED_WRITE: {

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -22,7 +22,7 @@ class VDUStreamProcessor {
 		int32_t read24_t(uint16_t timeout);
 		uint8_t readByte_b();
 		uint32_t readIntoBuffer(uint8_t * buffer, uint32_t length, uint16_t timeout);
-		uint32_t discardBytes(uint32_t length);
+		uint32_t discardBytes(uint32_t length, uint16_t timeout);
 
 		void vdu_colour();
 		void vdu_gcol();
@@ -140,7 +140,7 @@ class VDUStreamProcessor {
 //
 int16_t inline VDUStreamProcessor::readByte_t(uint16_t timeout = COMMS_TIMEOUT) {
 	auto read = inputStream->read();
-	if (read >= 0) {
+	if (read != -1) {
 		return read;
 	}
 
@@ -149,7 +149,7 @@ int16_t inline VDUStreamProcessor::readByte_t(uint16_t timeout = COMMS_TIMEOUT) 
 
 	do {
 		read = inputStream->read();
-		if (read >= 0) {
+		if (read != -1) {
 			return read;
 		}
 	} while (xTaskGetTickCountFromISR() - start < timeCheck);
@@ -163,9 +163,9 @@ int16_t inline VDUStreamProcessor::readByte_t(uint16_t timeout = COMMS_TIMEOUT) 
 //
 int32_t VDUStreamProcessor::readWord_t(uint16_t timeout = COMMS_TIMEOUT) {
 	auto l = readByte_t(timeout);
-	if (l >= 0) {
+	if (l != -1) {
 		auto h = readByte_t(timeout);
-		if (h >= 0) {
+		if (h != -1) {
 			return (h << 8) | l;
 		}
 	}
@@ -178,11 +178,11 @@ int32_t VDUStreamProcessor::readWord_t(uint16_t timeout = COMMS_TIMEOUT) {
 //
 int32_t VDUStreamProcessor::read24_t(uint16_t timeout = COMMS_TIMEOUT) {
 	auto l = readByte_t(timeout);
-	if (l >= 0) {
+	if (l != -1) {
 		auto m = readByte_t(timeout);
-		if (m >= 0) {
+		if (m != -1) {
 			auto h = readByte_t(timeout);
-			if (h >= 0) {
+			if (h != -1) {
 				return (h << 16) | (m << 8) | l;
 			}
 		}
@@ -228,7 +228,7 @@ uint32_t VDUStreamProcessor::readIntoBuffer(uint8_t * buffer, uint32_t length, u
 // Discard a given number of bytes from input stream
 // Returns 0 on success, or the number of bytes remaining if timed out
 //
-uint32_t VDUStreamProcessor::discardBytes(uint32_t length) {
+uint32_t VDUStreamProcessor::discardBytes(uint32_t length, uint16_t timeout = COMMS_TIMEOUT) {
 	uint32_t remaining = length;
 	auto bufferSize = 64;
 	auto readSize = bufferSize;
@@ -238,7 +238,7 @@ uint32_t VDUStreamProcessor::discardBytes(uint32_t length) {
 		if (remaining < readSize) {
 			readSize = remaining;
 		}
-		if (readIntoBuffer(buffer.get(), readSize) != 0) {
+		if (readIntoBuffer(buffer.get(), readSize, timeout) != 0) {
 			// timed out
 			return remaining;
 		}


### PR DESCRIPTION
adds compiler optimisation flags (for platformio builds)

uses native timeout functionality of the Stream class for the eZ80 input stream.  our existing timeout functionality was actually redundant if we just configure the input stream correctly.  this greatly reduces the complexity of all stream read calls, providing a significant performance boost for all VDU command processing