### PR TITLE
ensure scroll will _definitely_ use correct fill

### DIFF
--- a/video/graphics.h
+++ b/video/graphics.h
@@ -859,6 +859,7 @@ void scrollRegion(Rect * region, uint8_t direction, int16_t movement) {
 		if (direction == 3) ttxt_instance.scroll();
 	} else {
 		canvas->setPenColor(tbg);
+		canvas->setBrushColor(tbg);
 		canvas->setPaintOptions(tpo);
 		auto moveX = 0;
 		auto moveY = 0;


### PR DESCRIPTION
underlying vdp-gl scroll function uses `getActualBrushColor` to work out pixel to fill with.  this is affected by the paint options, and will pick either brush or pen colour depending on whether `swapFGBG` is set in the current `paintOptions`.

code had previously only been explicitly setting pen colour.  this was an oversight.  for completeness, we now explicitly set both.