### PR TITLE
Enhanced cursor support

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -34,7 +34,8 @@
 
 #define GPIO_ITRP				17		// VSync Interrupt Pin - for reference only
 
-#define CURSOR_PHASE			800		// Cursor blink phase (ms)
+#define CURSOR_PHASE			640		// Cursor blink phase (ms)
+#define CURSOR_FAST_PHASE		320		// Cursor blink phase (ms)
 
 // Commands for VDU 23, 0, n
 //

--- a/video/agon.h
+++ b/video/agon.h
@@ -38,6 +38,8 @@
 
 // Commands for VDU 23, 0, n
 //
+#define VDP_CURSOR_VSTART		0x0A	// Cursor start line offset (0-15)
+#define VDP_CURSOR_VEND			0x0B	// Cursor end line offset
 #define VDP_GP					0x80	// General poll data
 #define VDP_KEYCODE				0x81	// Keyboard data
 #define VDP_CURSOR				0x82	// Cursor positions
@@ -48,6 +50,8 @@
 #define VDP_RTC					0x87	// RTC
 #define VDP_KEYSTATE			0x88	// Keyboard repeat rate and LED status
 #define VDP_MOUSE				0x89	// Mouse data
+#define VDP_CURSOR_HSTART		0x8A	// Cursor start row offset (0-15)
+#define VDP_CURSOR_HEND			0x8B	// Cursor end row offset
 #define VDP_UDG					0x90	// User defined characters
 #define VDP_UDG_RESET			0x91	// Reset UDGs
 #define VDP_MAP_CHAR_TO_BITMAP	0x92	// Map a character to a bitmap

--- a/video/cursor.h
+++ b/video/cursor.h
@@ -31,6 +31,8 @@ typedef union {
 Point			textCursor;						// Text cursor
 Point *			activeCursor = &textCursor;		// Pointer to the active text cursor (textCursor or p1)
 bool			cursorEnabled = true;			// Cursor visibility
+bool			cursorFlashing = true;			// Cursor is flashing
+uint16_t		cursorFlashRate = CURSOR_PHASE;	// Cursor flash rate
 CursorBehaviour cursorBehaviour;				// New cursor behavior
 bool 			pagedMode = false;				// Is output paged or not? Set by VDU 14 and 15
 uint8_t			pagedModeCount = 0;				// Scroll counter for paged mode

--- a/video/cursor.h
+++ b/video/cursor.h
@@ -14,12 +14,27 @@ extern uint8_t	fontH;
 extern void drawCursor(Point p);
 extern void scrollRegion(Rect * r, uint8_t direction, int16_t amount);
 
+typedef union {
+	uint8_t value = 0;
+	struct {
+		uint8_t scrollProtect : 1;
+		uint8_t invertHorizontal : 1;
+		uint8_t invertVertical : 1;
+		uint8_t flipXY : 1;
+		uint8_t yWrap : 1;
+		uint8_t xHold : 1;
+		uint8_t grNoSpecialActions : 1;
+		uint8_t _undefined : 1;
+	};
+} CursorBehaviour;
+
 Point			textCursor;						// Text cursor
-Point *			activeCursor;					// Pointer to the active text cursor (textCursor or p1)
+Point *			activeCursor = &textCursor;		// Pointer to the active text cursor (textCursor or p1)
 bool			cursorEnabled = true;			// Cursor visibility
-uint8_t			cursorBehaviour = 0;			// Cursor behavior
+CursorBehaviour cursorBehaviour;				// New cursor behavior
 bool 			pagedMode = false;				// Is output paged or not? Set by VDU 14 and 15
 uint8_t			pagedModeCount = 0;				// Scroll counter for paged mode
+bool			pendingNewline = false;			// Scroll protect option, pending newline flag
 
 
 // Render a cursor at the current screen position
@@ -43,34 +58,122 @@ inline void setActiveCursor(Point * cursor) {
 }
 
 inline void setCursorBehaviour(uint8_t setting, uint8_t mask = 0xFF) {
-	cursorBehaviour = (cursorBehaviour & mask) ^ setting;
+	cursorBehaviour.value = (cursorBehaviour.value & mask) ^ setting;
 }
 
 // Move the active cursor to the leftmost position in the viewport
 //
 void cursorCR() {
-	activeCursor->X = activeViewport->X1;
+	if (cursorBehaviour.flipXY) {
+		activeCursor->Y = cursorBehaviour.invertVertical ? (activeViewport->Y2 + 1 - fontH) : activeViewport->Y1;
+	} else {
+		activeCursor->X = cursorBehaviour.invertHorizontal ? (activeViewport->X2 + 1 - fontW) : activeViewport->X1;
+	}
+}
+
+bool cursorScrollOrWrap(bool clearPending = false) {
+	bool outsideY = activeCursor->Y < activeViewport->Y1 || activeCursor->Y >= activeViewport->Y2;
+	bool outsideX = activeCursor->X < activeViewport->X1 || activeCursor->X >= activeViewport->X2;
+	if (!outsideX && !outsideY) {
+		// cursor within current viewport, so do nothing
+		return false;
+	}
+	if (clearPending) {
+		pendingNewline = false;
+	}
+
+	debug_log("cursorScrollOrWrap: cursor: %d,%d viewport %d,%d -> %d,%d\n\r", activeCursor->X, activeCursor->Y, activeViewport->X1, activeViewport->Y1, activeViewport->X2, activeViewport->Y2);
+	if (textCursorActive() && !cursorBehaviour.yWrap) {
+		debug_log("text cursor check for wrap\n\r");
+		// text cursor, scrolling for our Y direction is enabled
+		if (cursorBehaviour.flipXY && outsideX || !cursorBehaviour.flipXY && outsideY) {
+			// we are outside of our cursor Y direction
+			// scroll in appropriate direction by 1 character (movement amount 0)
+			// our direction will be a 6 or 7, depending on whether we're outside the "top" or "bottom"
+			if (outsideX) {
+				if (activeCursor->X < activeViewport->X1) {
+					if (cursorBehaviour.scrollProtect && !pendingNewline) {
+						pendingNewline = true;
+					} else {
+						scrollRegion(activeViewport, cursorBehaviour.invertVertical ? 7 : 6, 0);
+						activeCursor->X = activeViewport->X1;
+						pendingNewline = false;
+					}
+				} else {
+					if (cursorBehaviour.scrollProtect && !pendingNewline) {
+						debug_log("scroll protect setting pending newline\n\r");
+						pendingNewline = true;
+					} else {
+						scrollRegion(activeViewport, cursorBehaviour.invertVertical ? 6 : 7, 0);
+						activeCursor->X = activeViewport->X2 + 1 - fontW;
+						pendingNewline = false;
+					}
+				}
+			} else {
+				if (activeCursor->Y < activeViewport->Y1) {
+					if (cursorBehaviour.scrollProtect && !pendingNewline) {
+						pendingNewline = true;
+					} else {
+						scrollRegion(activeViewport, cursorBehaviour.invertHorizontal ? 7 : 6, 0);
+						activeCursor->Y = activeViewport->Y1;
+						pendingNewline = false;
+					}
+				} else {
+					if (cursorBehaviour.scrollProtect && !pendingNewline) {
+						pendingNewline = true;
+					} else {
+						scrollRegion(activeViewport, cursorBehaviour.invertHorizontal ? 6 : 7, 0);
+						activeCursor->Y = activeViewport->Y2 + 1 - fontH;
+						pendingNewline = false;
+					}
+				}
+			}
+			return true;
+		}
+	}
+
+	// graphics cursor, or text cursor with wrap enabled
+	if (!textCursorActive() && cursorBehaviour.grNoSpecialActions) {
+		debug_log("no wrap\n\r");
+		return false;
+	}
+
+	debug_log("wrapping\n\r");
+	// here we just wrap everything
+	// TODO these don't work properly if our viewport isn't a multiple of fontW or fontH
+	if (activeCursor->X < activeViewport->X1) {
+		activeCursor->X = activeViewport->X2 + 1 - fontW;
+	}
+	if (activeCursor->X >= activeViewport->X2) {
+		activeCursor->X = activeViewport->X1;
+	}
+	if (activeCursor->Y < activeViewport->Y1) {
+		activeCursor->Y = activeViewport->Y2 + 1 - fontH;
+	}
+	if (activeCursor->Y >= activeViewport->Y2) {
+		activeCursor->Y = activeViewport->Y1;
+	}
+	return true;
 }
 
 // Move the active cursor down a line
 //
 void cursorDown() {
-	activeCursor->Y += fontH;
-	//
-	// If in graphics mode, then don't scroll, wrap to top
-	// 
-	if (!textCursorActive()) {
-		if (activeCursor->Y > activeViewport->Y2) {	
-			activeCursor->Y = activeViewport->Y2;
-		}
-		return;
+	if (cursorBehaviour.flipXY) {
+		activeCursor->X += (cursorBehaviour.invertHorizontal ? -fontW : fontW);
+	} else {
+		activeCursor->Y += (cursorBehaviour.invertVertical ? -fontH : fontH);
 	}
 	//
-	// Using the text cursor, so handle paging and scrolling
+	// handle paging if we need to
 	//
-	if (pagedMode) {
+	if (textCursorActive() && pagedMode) {
 		pagedModeCount++;
-		if (pagedModeCount >= (activeViewport->Y2 - activeViewport->Y1 + 1) / fontH) {
+		if (pagedModeCount >= (
+				cursorBehaviour.flipXY ? (activeViewport->X2 - activeViewport->X1 + 1) / fontW
+					: (activeViewport->Y2 - activeViewport->Y1 + 1) / fontH
+			)
+		) {
 			pagedModeCount = 0;
 			uint8_t ascii;
 			uint8_t vk;
@@ -91,63 +194,103 @@ void cursorDown() {
 	//
 	// Check if scroll required
 	//
-	if (activeCursor->Y + fontH - 1 > activeViewport->Y2) {
-		activeCursor->Y -= fontH;
-		if (~cursorBehaviour & 0x01) {
-			scrollRegion(activeViewport, 3, fontH);
-		}
-		else {
-			activeCursor->X = activeViewport->X2 + 1;
-		}
-	}
+	cursorScrollOrWrap();
+	// if (activeCursor->Y + fontH - 1 > activeViewport->Y2) {
+	// 	activeCursor->Y -= fontH;
+	// 	if (~cursorBehaviour & 0x01) {
+	// 		scrollRegion(activeViewport, 3, fontH);
+	// 	}
+	// 	else {
+	// 		activeCursor->X = activeViewport->X2 + 1;
+	// 	}
+	// }
 }
 
 // Move the active cursor up a line
 //
 void cursorUp() {
-	activeCursor->Y -= fontH;
-	if (activeCursor->Y < activeViewport->Y1) {
-		activeCursor->Y = activeViewport->Y1;
+	if (cursorBehaviour.flipXY) {
+		activeCursor->X += (cursorBehaviour.invertHorizontal ? fontW : -fontW);
+	} else {
+		activeCursor->Y += (cursorBehaviour.invertVertical ? fontH : -fontH);
 	}
+	cursorScrollOrWrap();
 }
 
 // Move the active cursor back one character
 //
 void cursorLeft() {
-	activeCursor->X -= fontW;											
-	if (activeCursor->X < activeViewport->X1) {						// If moved past left edge of active viewport then
-		activeCursor->X = activeViewport->X1;						// Lock it there
+	pendingNewline = false;
+	if (cursorBehaviour.flipXY) {
+		activeCursor->Y += (cursorBehaviour.invertVertical ? fontH : -fontH);
+	} else {
+		activeCursor->X += (cursorBehaviour.invertHorizontal ? fontW : -fontW);
 	}
 }
 
 // Advance the active cursor right one character
 //
 void cursorRight() {
-	activeCursor->X += fontW;											
-	if (activeCursor->X > activeViewport->X2) {						// If advanced past right edge of active viewport
-		if (textCursorActive() || (~cursorBehaviour & 0x40)) {		// If it is a text cursor or VDU 5 CR/LF is enabled then
-			cursorCR();												// Do carriage return
-			cursorDown();											// and line feed
+	if (cursorBehaviour.flipXY) {
+		activeCursor->Y += (cursorBehaviour.invertVertical ? -fontH : fontH);
+	} else {
+		activeCursor->X += (cursorBehaviour.invertHorizontal ? -fontW : fontW);
+	}
+	debug_log("cursorRight: %d %d\n\r", activeCursor->X, activeCursor->Y);
+	if (cursorScrollOrWrap()) {	// we have scrolled or wrapped to opposite edge, so may need to move cursor down
+		if (textCursorActive() && !cursorBehaviour.yWrap) {
+			cursorDown();
 		}
+		// if (textCursorActive() || (~cursorBehaviour & 0x40)) {		// If it is a text cursor or VDU 5 CR/LF is enabled then
+		// 	cursorCR();												// Do carriage return
+		// 	cursorDown();											// and line feed
+		// }
 	}
 }
 
 // Move the active cursor to the top-left position in the viewport
 //
 void cursorHome() {
-	activeCursor->X = activeViewport->X1;
-	activeCursor->Y = activeViewport->Y1;
+	if (cursorBehaviour.flipXY) {
+		activeCursor->X = cursorBehaviour.invertHorizontal ? (activeViewport->X2 + 1 - fontW) : activeViewport->X1;
+		activeCursor->Y = cursorBehaviour.invertVertical ? (activeViewport->Y2 + 1 - fontH) : activeViewport->Y1;
+	} else {
+		activeCursor->X = cursorBehaviour.invertHorizontal ? (activeViewport->X2 + 1 - fontW) : activeViewport->X1;
+		activeCursor->Y = cursorBehaviour.invertVertical ? (activeViewport->Y2 + 1 - fontH) : activeViewport->Y1;
+	}
 }
 
 // TAB(x,y)
 //
 void cursorTab(uint8_t x, uint8_t y) {
-  if (textViewport.X1 + x * fontW <= textViewport.X2 &&
-      textViewport.Y1 + y * fontW <= textViewport.Y2)
-  {
-	  textCursor.X = textViewport.X1 + x * fontW;
-	  textCursor.Y = textViewport.Y1 + y * fontH;
-  }
+	int xPos, yPos;
+	if (cursorBehaviour.flipXY) {
+		if (cursorBehaviour.invertHorizontal) {
+			xPos = activeViewport->X2 - ((y + 1) * fontW);
+		} else {
+			xPos = activeViewport->X1 + (y * fontW);
+		}
+		if (cursorBehaviour.invertVertical) {
+			yPos = activeViewport->Y2 - ((x + 1) * fontH);
+		} else {
+			yPos = activeViewport->Y1 + (x * fontH);
+		}
+	} else {
+		if (cursorBehaviour.invertHorizontal) {
+			xPos = activeViewport->X2 - ((x + 1) * fontW);
+		} else {
+			xPos = activeViewport->X1 + (x * fontW);
+		}
+		if (cursorBehaviour.invertVertical) {
+			yPos = activeViewport->Y2 - ((y + 1) * fontH);
+		} else {
+			yPos = activeViewport->Y1 + (y * fontH);
+		}
+	}
+	if (activeViewport->X1 <= xPos && xPos < activeViewport->X2 && activeViewport->Y1 <= yPos && yPos < activeViewport->Y2) {
+		activeCursor->X = xPos;
+		activeCursor->Y = yPos;
+	}
 }
 
 void setPagedMode(bool mode = pagedMode) {
@@ -160,12 +303,8 @@ void setPagedMode(bool mode = pagedMode) {
 void resetCursor() {
 	setActiveCursor(getTextCursor());
 	cursorEnabled = true;
-	cursorBehaviour = 0;
+	cursorBehaviour.value = 0;
 	setPagedMode(false);
-}
-
-void homeCursor() {
-	textCursor = Point(activeViewport->X1, activeViewport->Y1);
 }
 
 inline void enableCursor(bool enable = true) {

--- a/video/graphics.h
+++ b/video/graphics.h
@@ -1,6 +1,7 @@
 #ifndef GRAPHICS_H
 #define GRAPHICS_H
 
+#include <algorithm>
 #include <vector>
 
 #include <fabgl.h>
@@ -681,9 +682,11 @@ void setClippingRect(Rect rect) {
 //
 void drawCursor(Point p) {
 	if (textCursorActive()) {
-		canvas->setBrushColor(tfg);
-		canvas->setPaintOptions(cpo);
-		canvas->fillRectangle(p.X + cursorHStart, p.Y + cursorVStart, p.X + cursorHEnd, p.Y + cursorVEnd);
+		if (cursorHStart < fontW && cursorHStart <= cursorHEnd && cursorVStart < fontH && cursorVStart <= cursorVEnd) {
+			canvas->setBrushColor(tfg);
+			canvas->setPaintOptions(cpo);
+			canvas->fillRectangle(p.X + cursorHStart, p.Y + cursorVStart, p.X + std::min(((int)cursorHEnd), fontW - 1), p.Y + std::min(((int)cursorVEnd), fontH - 1));
+		}
 	}
 }
 

--- a/video/graphics.h
+++ b/video/graphics.h
@@ -626,8 +626,8 @@ void plotCharacter(char c) {
 	if (ttxtMode) {
 		ttxt_instance.draw_char(activeCursor->X, activeCursor->Y, c);
 	} else {
-		if (pendingNewline) {
-			cursorScrollOrWrap(true);
+		if (cursorBehaviour.scrollProtect) {
+			cursorAutoNewline();
 		}
 		bool isTextCursor = textCursorActive();
 		auto bitmap = getBitmapFromChar(c);
@@ -648,7 +648,7 @@ void plotCharacter(char c) {
 		}
 	}
 	if (!cursorBehaviour.xHold) {
-		cursorRight();
+		cursorRight(cursorBehaviour.scrollProtect);
 	}
 }
 

--- a/video/graphics.h
+++ b/video/graphics.h
@@ -656,7 +656,6 @@ void plotCharacter(char c) {
 // Backspace plot
 //
 void plotBackspace() {
-	debug_log("plotBackspace\n\r");
 	cursorLeft();
 	if (ttxtMode) {
 		ttxt_instance.draw_char(activeCursor->X, activeCursor->Y, ' ');

--- a/video/graphics.h
+++ b/video/graphics.h
@@ -28,6 +28,10 @@ RGB888			tfg, tbg;						// Text foreground and background colour
 uint8_t			gfgc, gbgc, tfgc, tbgc;			// Logical colour values for graphics and text
 uint8_t			fontW;							// Font width
 uint8_t			fontH;							// Font height
+uint8_t			cursorVStart;					// Cursor vertical start offset
+uint8_t			cursorVEnd;						// Cursor vertical end
+uint8_t			cursorHStart;					// Cursor horizontal start offset
+uint8_t			cursorHEnd;						// Cursor horizontal end
 uint8_t			videoMode;						// Current video mode
 bool			legacyModes = false;			// Default legacy modes being false
 bool			rectangularPixels = false;		// Pixels are square by default
@@ -669,7 +673,7 @@ void setClippingRect(Rect rect) {
 void drawCursor(Point p) {
 	canvas->setBrushColor(tfg);
 	canvas->setPaintOptions(cpo);
-	canvas->fillRectangle(p.X, p.Y, p.X + fontW - 1, p.Y + fontH - 1);
+	canvas->fillRectangle(p.X + cursorHStart, p.Y + cursorVStart, p.X + cursorHEnd, p.Y + cursorVEnd);
 }
 
 
@@ -854,6 +858,10 @@ int8_t change_mode(uint8_t mode) {
 	rectangularPixels = ((float)canvasW / (float)canvasH) > 2;
 	fontW = canvas->getFontInfo()->width;
 	fontH = canvas->getFontInfo()->height;
+	cursorVStart = 0;
+	cursorVEnd = fontH - 1;
+	cursorHStart = 0;
+	cursorHEnd = fontW - 1;
 	viewportReset();
 	setOrigin(0,0);
 	pushPoint(0,0);

--- a/video/graphics.h
+++ b/video/graphics.h
@@ -18,6 +18,7 @@
 fabgl::PaintOptions			gpofg;				// Graphics paint options foreground
 fabgl::PaintOptions			gpobg;				// Graphics paint options background
 fabgl::PaintOptions			tpo;				// Text paint options
+fabgl::PaintOptions			cpo;				// Cursor paint options
 
 Point			p1, p2, p3;						// Coordinate store for plot
 Point			rp1;							// Relative coordinates store for plot
@@ -241,6 +242,7 @@ void restorePalette() {
 	tfg = colourLookup[0x3F];
 	tbg = colourLookup[0x00];
 	tpo = getPaintOptions(fabgl::PaintMode::Set, tpo);
+	cpo = getPaintOptions(fabgl::PaintMode::XOR, tpo);
 	gpofg = getPaintOptions(fabgl::PaintMode::Set, gpofg);
 	gpobg = getPaintOptions(fabgl::PaintMode::Set, gpobg);
 }
@@ -665,7 +667,9 @@ void setClippingRect(Rect rect) {
 // Draw cursor
 //
 void drawCursor(Point p) {
-	canvas->swapRectangle(p.X, p.Y, p.X + fontW - 1, p.Y + fontH - 1);
+	canvas->setBrushColor(tfg);
+	canvas->setPaintOptions(cpo);
+	canvas->fillRectangle(p.X, p.Y, p.X + fontW - 1, p.Y + fontH - 1);
 }
 
 

--- a/video/vdu.h
+++ b/video/vdu.h
@@ -67,15 +67,14 @@ void VDUStreamProcessor::vdu(uint8_t c) {
 			setCharacterOverwrite(true);
 			setActiveCursor(getTextCursor());
 			setActiveViewport(VIEWPORT_TEXT);
+			sendModeInformation();
 			break;
 		case 0x05:
 			// enable graphics cursor
 			setCharacterOverwrite(false);
 			setActiveCursor(getGraphicsCursor());
-			// TODO double-check whether this moveTo is needed
-			// as PLOT now also does a moveTo
-			// moveTo();
 			setActiveViewport(VIEWPORT_GRAPHICS);
+			sendModeInformation();
 			break;
 		case 0x06:
 			// Resume VDU system
@@ -139,12 +138,14 @@ void VDUStreamProcessor::vdu(uint8_t c) {
 			break;
 		case 0x18:	// Define a graphics viewport
 			vdu_graphicsViewport();
+			sendModeInformation();
 			break;
 		case 0x19:	// PLOT
 			vdu_plot();
 			break;
 		case 0x1A:	// Reset text and graphics viewports
 			vdu_resetViewports();
+			sendModeInformation();
 			break;
 		case 0x1B: { // VDU 27
 			auto b = readByte_t();	if (b == -1) return;
@@ -153,6 +154,7 @@ void VDUStreamProcessor::vdu(uint8_t c) {
 		}	break;
 		case 0x1C:	// Define a text viewport
 			vdu_textViewport();
+			sendModeInformation();
 			break;
 		case 0x1D:	// VDU_29
 			vdu_origin();

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -400,9 +400,10 @@ void VDUStreamProcessor::sendTime() {
 // VDU 23, 0, &86: Send MODE information (screen details)
 //
 void VDUStreamProcessor::sendModeInformation() {
-	// TODO consider whether charsX and charsY should be based on the active viewport
-	uint8_t charsX = canvasW / fontW;
-	uint8_t charsY = canvasH / fontH;
+	// our character dimensions are for the currently active viewport
+	// needed as MOS's line editing system uses these
+	uint8_t charsX = activeViewport->width() / fontW;
+	uint8_t charsY = activeViewport->height() / fontH;
 	uint8_t packet[] = {
 		(uint8_t) (canvasW & 0xFF),			// Width in pixels (L)
 		(uint8_t) ((canvasW >> 8) & 0xFF),	// Width in pixels (H)

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -191,7 +191,7 @@ void VDUStreamProcessor::vdu_sys_video() {
 		case VDP_CURSOR_HSTART: {		// VDU 23, 0, &8A, offset
 			auto offset = readByte_t();	// Set the horizontal start of the cursor
 			if (offset >= 0)
-				cursorHStart = offset & 0x0F;
+				cursorHStart = offset;
 		}	break;
 		case VDP_CURSOR_HEND: {			// VDU 23, 0, &8B, offset
 			auto offset = readByte_t();	// Set the vertical end of the cursor

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -119,6 +119,16 @@ void VDUStreamProcessor::vdu_sys_video() {
 	auto mode = readByte_t();
 
 	switch (mode) {
+		case VDP_CURSOR_VSTART: {		// VDU 23, 0, &0A, offset
+			auto offset = readByte_t();	// Set the vertical start of the cursor
+			if (offset >= 0)
+				cursorVStart = offset & 0x0F;
+		}	break;
+		case VDP_CURSOR_VEND: {			// VDU 23, 0, &0B, offset
+			auto offset = readByte_t();	// Set the vertical end of the cursor
+			if (offset >= 0)
+				cursorVEnd = offset;
+		}	break;
 		case VDP_GP: {					// VDU 23, 0, &80
 			sendGeneralPoll();			// Send a general poll packet
 		}	break;
@@ -152,6 +162,16 @@ void VDUStreamProcessor::vdu_sys_video() {
 		}	break;
 		case VDP_MOUSE: {				// VDU 23, 0, &89, command, <args>
 			vdu_sys_mouse();
+		}	break;
+		case VDP_CURSOR_HSTART: {		// VDU 23, 0, &8A, offset
+			auto offset = readByte_t();	// Set the horizontal start of the cursor
+			if (offset >= 0)
+				cursorHStart = offset & 0x0F;
+		}	break;
+		case VDP_CURSOR_HEND: {			// VDU 23, 0, &8B, offset
+			auto offset = readByte_t();	// Set the vertical end of the cursor
+			if (offset >= 0)
+				cursorHEnd = offset;
 		}	break;
 		case VDP_UDG: {					// VDU 23, 0, &90, c, <args>
 			auto c = readByte_t();		// Redefine a display character

--- a/video/video.ino
+++ b/video/video.ino
@@ -115,6 +115,7 @@ void loop() {
 
 		if (processor->byteAvailable()) {
 			if (drawCursor) {
+				cursorTime = millis();
 				drawCursor = false;
 				do_cursor();
 			}

--- a/video/video.ino
+++ b/video/video.ino
@@ -102,7 +102,7 @@ void loop() {
 		if (processTerminal()) {
 			continue;
 		}
-		if (millis() - cursorTime > CURSOR_PHASE) {
+		if (cursorFlashing && (millis() - cursorTime > cursorFlashRate)) {
 			cursorTime = millis();
 			drawCursor = !drawCursor;
 			if (ttxtMode) {
@@ -115,11 +115,13 @@ void loop() {
 
 		if (processor->byteAvailable()) {
 			if (drawCursor) {
-				cursorTime = millis();
-				drawCursor = false;
 				do_cursor();
 			}
 			processor->processNext();
+			if (drawCursor || !cursorFlashing) {
+				drawCursor = true;
+				do_cursor();
+			}
 		}
 	}
 }


### PR DESCRIPTION
builds on #178 

adds support for all different cursor behaviours set via VDU 23,16,x,y

needs to be fully tested to compare to how RISC OS behaves

also includes preliminary support for `VDU 23,0,10,n` and `VDU 23,0,11,n` to set cursor display start/end row plus `VDU 23,0,&8A,n` and `VDU 23,0,&8B,n` to adjust cursor display start/end column (the latter wasn't part of what a Beeb could do).  this also includes the ability to set the flashing speed to fast (as opposed to the default slower flashing rate) and pick a "steady" (non-flashing) cursor.  `VDU 23,1,n` now supports options 2 and 3 for "steady" and "flashing" options instead of the previous off/on