### PR TITLE
more cursor fixes

### DIFF
--- a/video/graphics.h
+++ b/video/graphics.h
@@ -696,9 +696,7 @@ void drawCursor(Point p) {
 			canvas->fillRectangle(p.X + cursorHStart, p.Y + cursorVStart, p.X + std::min(((int)cursorHEnd), fontW - 1), p.Y + std::min(((int)cursorVEnd), fontH - 1));
 			canvas->setBrushColor(tfg);
 			canvas->fillRectangle(p.X + cursorHStart, p.Y + cursorVStart, p.X + std::min(((int)cursorHEnd), fontW - 1), p.Y + std::min(((int)cursorVEnd), fontH - 1));
-			if (ttxtMode) {
-				canvas->setPaintOptions(tpo);
-			}
+			canvas->setPaintOptions(tpo);
 		}
 	}
 }

--- a/video/video.ino
+++ b/video/video.ino
@@ -95,18 +95,19 @@ void setup() {
 // The main loop
 //
 void loop() {
-	bool drawCursor = false;
+	bool cursorShowing = false;
+	bool cursorTemporarilyHidden = false;
 	auto cursorTime = millis();
 
 	while (true) {
 		if (processTerminal()) {
 			continue;
 		}
-		if (cursorFlashing && (millis() - cursorTime > cursorFlashRate)) {
+		if (!cursorTemporarilyHidden && cursorFlashing && (millis() - cursorTime > cursorFlashRate)) {
 			cursorTime = millis();
-			drawCursor = !drawCursor;
+			cursorShowing = !cursorShowing;
 			if (ttxtMode) {
-				ttxt_instance.flash(drawCursor);
+				ttxt_instance.flash(cursorShowing);
 			}
 			do_cursor();
 		}
@@ -114,12 +115,14 @@ void loop() {
 		do_mouse();
 
 		if (processor->byteAvailable()) {
-			if (drawCursor) {
+			if (!cursorTemporarilyHidden && cursorShowing) {
+				cursorTemporarilyHidden = true;
 				do_cursor();
 			}
 			processor->processNext();
-			if (drawCursor || !cursorFlashing) {
-				drawCursor = true;
+			if (!processor->byteAvailable() && (cursorTemporarilyHidden || !cursorFlashing)) {
+				cursorShowing = true;
+				cursorTemporarilyHidden = false;
 				do_cursor();
 			}
 		}


### PR DESCRIPTION
ensures that paint options are always reset to text painting after drawing cursor, rather than only doing that for teletext mode.  this should fix rendering issues when terminal mode is enabled

improve logic that temporarily hides the cursor when processing VDU commands.  cursor will now remain hidden if there are pending commands, reducing the appearance of a flickery cursor when printing lots of text