### PR TITLE
even more cursor movement fixes

### DIFF
--- a/video/cursor.h
+++ b/video/cursor.h
@@ -81,15 +81,16 @@ int getYAdjustment() {
 Point getNormalisedCursorPosition(Point * cursor = activeCursor) {
 	Point p;
 	if (cursorBehaviour.flipXY) {
+		// our normalised Y needs to take values from X and vice versa
 		if (cursorBehaviour.invertHorizontal) {
-			p.X = activeViewport->Y2 - cursor->Y;
-		} else {
-			p.X = cursor->Y - activeViewport->Y1;
-		}
-		if (cursorBehaviour.invertVertical) {
 			p.Y = activeViewport->X2 - cursor->X;
 		} else {
 			p.Y = cursor->X - activeViewport->X1;
+		}
+		if (cursorBehaviour.invertVertical) {
+			p.X = activeViewport->Y2 - cursor->Y;
+		} else {
+			p.X = cursor->Y - activeViewport->Y1;
 		}
 	} else {
 		if (cursorBehaviour.invertHorizontal) {
@@ -108,16 +109,24 @@ Point getNormalisedCursorPosition(Point * cursor = activeCursor) {
 
 int getNormalisedViewportWidth() {
 	if (cursorBehaviour.flipXY) {
-		return activeViewport->height() - getYAdjustment() - (fontH - 1);
+		return activeViewport->height() - getYAdjustment();
 	}
 	return activeViewport->width() - getXAdjustment();
 }
 
 int getNormalisedViewportHeight() {
 	if (cursorBehaviour.flipXY) {
-		return activeViewport->width() - getXAdjustment() - (fontW - 1);
+		auto height = activeViewport->width() - getXAdjustment();
+		if (!cursorBehaviour.invertHorizontal) {
+			height -= fontW - 1;
+		}
+		return height;
 	}
-	return activeViewport->height() - getYAdjustment() - (fontH - 1);
+	auto height = activeViewport->height() - getYAdjustment();
+	if (!cursorBehaviour.invertVertical) {
+		height -= fontH - 1;
+	}
+	return height;
 }
 
 bool cursorIsOffRight() {
@@ -198,7 +207,7 @@ bool cursorScrollOrWrap() {
 			scrollRegion(activeViewport, 7, 0);
 			// move cursor up until it's within the viewport
 			do {
-				cursorUp(false);
+				cursorUp(true);
 			} while (cursorIsOffBottom());
 			return false;
 		}

--- a/video/graphics.h
+++ b/video/graphics.h
@@ -951,28 +951,28 @@ void scrollRegion(Rect * region, uint8_t direction, int16_t movement) {
 				break;
 			case 4:		// positive X
 				if (cursorBehaviour.flipXY) {
-					moveY = cursorBehaviour.invertHorizontal ? -1 : 1;
+					moveY = cursorBehaviour.invertVertical ? -1 : 1;
 				} else {
 					moveX = cursorBehaviour.invertHorizontal ? -1 : 1;
 				}
 				break;
 			case 5:		// negative X
 				if (cursorBehaviour.flipXY) {
-					moveY = cursorBehaviour.invertHorizontal ? 1 : -1;
+					moveY = cursorBehaviour.invertVertical ? 1 : -1;
 				} else {
 					moveX = cursorBehaviour.invertHorizontal ? 1 : -1;
 				}
 				break;
 			case 6:		// positive Y
 				if (cursorBehaviour.flipXY) {
-					moveX = cursorBehaviour.invertVertical ? -1 : 1;
+					moveX = cursorBehaviour.invertHorizontal ? -1 : 1;
 				} else {
 					moveY = cursorBehaviour.invertVertical ? -1 : 1;
 				}
 				break;
 			case 7:		// negative Y
 				if (cursorBehaviour.flipXY) {
-					moveX = cursorBehaviour.invertVertical ? 1 : -1;
+					moveX = cursorBehaviour.invertHorizontal ? 1 : -1;
 				} else {
 					moveY = cursorBehaviour.invertVertical ? 1 : -1;
 				}

--- a/video/version.h
+++ b/video/version.h
@@ -3,7 +3,7 @@
 
 #define		VERSION_MAJOR		2
 #define		VERSION_MINOR		7
-#define		VERSION_PATCH		2
+#define		VERSION_PATCH		3
 #define		VERSION_CANDIDATE	0			// Optional
 #define		VERSION_TYPE		"Release"	// RC, Alpha, Beta, etc.
 


### PR DESCRIPTION
fixes for:
scroll directions when cursor had flipped its X and Y wasn’t looking for the correct “invert” behaviour, so would scroll in the wrong direction

when cursor was off the bottom of the screen an infinite loop could happen with the “cursor up” to bring the cursor back onto the screen if certain cursor behaviours were set

incorrect off-screen detection meant that for some combinations of cursor behaviour a scroll would get forced one row early