### PR TITLE
add new “shift origin” command

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -66,6 +66,7 @@
 #define VDP_TEXT_VIEWPORT		0x9C	// Set text viewport using current graphics coordinates
 #define VDP_GRAPHICS_VIEWPORT	0x9D	// Set graphics viewport using current graphics coordinates
 #define VDP_GRAPHICS_ORIGIN		0x9E	// Set graphics origin using current graphics coordinates
+#define VDP_SHIFT_ORIGIN		0x9F	// Move origin to new position from graphics coordinates, and viewports too
 #define VDP_BUFFERED			0xA0	// Buffered commands
 #define VDP_UPDATER				0xA1	// Update VDP
 #define VDP_LOGICALCOORDS		0xC0	// Switch BBC Micro style logical coords on and off

--- a/video/context.h
+++ b/video/context.h
@@ -132,6 +132,7 @@ class Context {
 		Rect * getViewport(ViewportType type);
 		bool setTextViewport(Rect rect);
 		Point scale(int16_t X, int16_t Y);
+		Point invScale(Point p);
 
 		// Font management functions
 		const fabgl::FontInfo * getFont();
@@ -224,8 +225,9 @@ class Context {
 		bool setTextViewport();
 		uint8_t getNormalisedViewportCharWidth();
 		uint8_t getNormalisedViewportCharHeight();
-		inline void setOrigin(int x, int y);
+		void setOrigin(int x, int y);
 		void setOrigin();
+		void shiftOrigin();
 		void setLogicalCoords(bool b);
 		Point toCurrentCoordinates(int16_t X, int16_t Y);
 		Point toScreenCoordinates(int16_t X, int16_t Y);

--- a/video/context/graphics.h
+++ b/video/context/graphics.h
@@ -593,11 +593,13 @@ void Context::pushPoint(uint16_t x, uint16_t y) {
 // ensuring that the rect is on-screen coordinates
 //
 Rect Context::getGraphicsRect() {
-	return Rect(
-		std::max((int)0, (int)std::min(p1.X, p2.X)),
-		std::max((int)0, (int)std::min(p1.Y, p2.Y)),
-		std::min(canvasW - 1, (int)std::max(p1.X, p2.X)),
-		std::min(canvasH - 1, (int)std::max(p1.Y, p2.Y))
+	return defaultViewport.intersection(
+		Rect(
+			std::min(p1.X, p2.X),
+			std::min(p1.Y, p2.Y),
+			std::max(p1.X, p2.X),
+			std::max(p1.Y, p2.Y)
+		)
 	);
 }
 

--- a/video/vdu.h
+++ b/video/vdu.h
@@ -325,6 +325,7 @@ void VDUStreamProcessor::vdu_resetViewports() {
 	context->viewportReset();
 	// reset cursors too (according to BBC BASIC manual)
 	context->cursorHome();
+	context->setOrigin(0, 0);
 	context->pushPoint(0, 0);
 	debug_log("vdu_resetViewport\n\r");
 }

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -268,6 +268,10 @@ void VDUStreamProcessor::vdu_sys_video() {
 			// Set graphics origin using latest graphics coordintes
 			context->setOrigin();
 		}	break;
+		case VDP_SHIFT_ORIGIN: {		// VDU 23, 0, &9F
+			// Shift graphics origin and viewports using latest graphics coordintes
+			context->shiftOrigin();
+		}	break;
 		case VDP_BUFFERED: {			// VDU 23, 0, &A0, bufferId; command, <args>
 			vdu_sys_buffered();
 		}	break;


### PR DESCRIPTION
which will move the origin point to current graphics coordinates, and moves the currently set viewports by the same delta by which the origin has been moved.  shifted viewports are ensured to be on-screen.

setOrigin to graphics coordinates can now move origin to off-screen coordinates.  (it was previously restricting the new origin point to be on-screen, which isn’t necessary)

set origin commands now work correctly with relative plot commands

origin in context is now proper screen coordinates, including Y adjustment, instead of just a value scaled to match screen coordinates

bug fix:
VDU 26 the “reset viewports” command should have been resetting the graphics origin - it now does that