### PR TITLE
ensure that buffers are properly cleared

### DIFF
--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -16,10 +16,11 @@
 #include "agon_audio.h"
 #include "audio_sample.h"
 #include "buffers.h"
-#include "types.h"
 #include "envelopes/adsr.h"
 #include "envelopes/multiphase_adsr.h"
 #include "envelopes/frequency.h"
+#include "types.h"
+#include "vdu_stream_processor.h"
 
 // Audio VDU command support (VDU 23, 0, &85, <args>)
 //

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -105,6 +105,7 @@ class VDUStreamProcessor {
 		void vdu_sys_buffered();
 		uint32_t bufferWrite(uint16_t bufferId, uint32_t size);
 		void bufferCall(uint16_t bufferId, AdvancedOffset offset);
+		void bufferRemoveUsers(uint16_t bufferId);
 		void bufferClear(uint16_t bufferId);
 		std::shared_ptr<WritableBufferStream> bufferCreate(uint16_t bufferId, uint32_t size);
 		void setOutputStream(uint16_t bufferId);


### PR DESCRIPTION
when a buffered command call clears a buffer it should ensure that all users of that buffer (bitmaps, fonts, samples) should get cleared too