### PR TITLE
ensure `print` doesn’t peek

### DIFF
--- a/video/vdu.h
+++ b/video/vdu.h
@@ -13,7 +13,7 @@ extern HardwareSerial DBGSerial;
 
 // Handle VDU commands
 //
-void VDUStreamProcessor::vdu(uint8_t c) {
+void VDUStreamProcessor::vdu(uint8_t c, bool usePeek) {
 	// We want to send raw chars back to the debugger
 	// this allows binary (faster) data transfer in ZDI mode
 	// to inspect memory and register values
@@ -83,7 +83,7 @@ void VDUStreamProcessor::vdu(uint8_t c) {
 			playNote(0, 100, 750, 125);
 			break;
 		case 0x08:	// Cursor Left
-			if (!context->textCursorActive() && peekByte_t(20) == 0x20) {
+			if (!context->textCursorActive() && usePeek && peekByte_t(FAST_COMMS_TIMEOUT) == 0x20) {
 				// left followed by a space is almost certainly a backspace
 				// but MOS doesn't send backspaces to delete characters on line edits
 				context->plotBackspace();
@@ -152,7 +152,7 @@ void VDUStreamProcessor::vdu(uint8_t c) {
 			break;
 		case 0x1B: { // VDU 27
 			auto b = readByte_t();	if (b == -1) return;
-			vdu_print(b);
+			vdu_print(b, usePeek);
 		}	break;
 		case 0x1C:	// Define a text viewport
 			vdu_textViewport();
@@ -169,7 +169,7 @@ void VDUStreamProcessor::vdu(uint8_t c) {
 			break;
 		case 0x20 ... 0x7E:
 		case 0x80 ... 0xFF:
-			vdu_print(c);
+			vdu_print(c, usePeek);
 			break;
 		case 0x7F:	// Backspace
 			context->plotBackspace();
@@ -180,7 +180,7 @@ void VDUStreamProcessor::vdu(uint8_t c) {
 // VDU "print" command
 // will output to "printer", if enabled
 //
-void VDUStreamProcessor::vdu_print(char c) {
+void VDUStreamProcessor::vdu_print(char c, bool usePeek) {
 	if (printerOn && !consoleMode) {
 		// if consoleMode is enabled we're echoing everything back anyway
 		DBGSerial.write(c);
@@ -189,26 +189,28 @@ void VDUStreamProcessor::vdu_print(char c) {
 	std::string s;
 	s += c;
 	// gather our string for printing
-	for (;;) {
-		auto next = peekByte_t(FAST_COMMS_TIMEOUT);
-		if (next == 27) {
-			readByte_t();
-			if (consoleMode) {
-				DBGSerial.write(next);
-			}
-			next = readByte_t(FAST_COMMS_TIMEOUT);
-			if (next == -1) {
+	if (usePeek) {
+		for (;;) {
+			auto next = peekByte_t(FAST_COMMS_TIMEOUT);
+			if (next == 27) {
+				readByte_t();
+				if (consoleMode) {
+					DBGSerial.write(next);
+				}
+				next = readByte_t(FAST_COMMS_TIMEOUT);
+				if (next == -1) {
+					break;
+				}
+				s += (char)next;
+			} else if (next != -1 && ((next >= 0x20 && next <= 0x7E) || (next >= 0x80 && next <= 0xFF))) {
+				s += (char)next;
+				readByte_t();
+			} else {
 				break;
 			}
-			s += (char)next;
-		} else if (next != -1 && ((next >= 0x20 && next <= 0x7E) || (next >= 0x80 && next <= 0xFF))) {
-			s += (char)next;
-			readByte_t();
-		} else {
-			break;
-		}
-		if (printerOn) {
-			DBGSerial.write(next);
+			if (printerOn) {
+				DBGSerial.write(next);
+			}
 		}
 	}
 	context->plotString(s);

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -41,7 +41,7 @@ class VDUStreamProcessor {
 		uint32_t discardBytes(uint32_t length, uint16_t timeout);
 		int16_t peekByte_t(uint16_t timeout);
 
-		void vdu_print(char c);
+		void vdu_print(char c, bool usePeek);
 		void vdu_colour();
 		void vdu_gcol();
 		void vdu_palette();
@@ -179,7 +179,7 @@ class VDUStreamProcessor {
 			context->showCursor();
 		}
 
-		void vdu(uint8_t c);
+		void vdu(uint8_t c, bool usePeek = true);
 
 		void wait_eZ80();
 		void sendModeInformation();

--- a/video/video.ino
+++ b/video/video.ino
@@ -136,7 +136,7 @@ void do_keyboard() {
 				case 7:		// Bell
 				case 12:	// CLS
 				case 14 ... 15:	// paged mode on/off
-					processor->vdu(keycode);
+					processor->vdu(keycode, false);
 					break;
 				case 16:
 					// control-P toggles "printer" on R.T.Russell's BASIC
@@ -350,7 +350,7 @@ bool processTerminal() {
 
 void print(char const * text) {
 	for (auto i = 0; i < strlen(text); i++) {
-		processor->vdu(text[i]);
+		processor->vdu(text[i], false);
 	}
 }
 


### PR DESCRIPTION
add a `usePeek` argument to the `vdu` function, allowing the `print` function to disable peeking for more characters

this fixes issues observed with hexload