### PR TITLE
cursor down should perform an autonewline

### DIFF
--- a/video/context/cursor.h
+++ b/video/context/cursor.h
@@ -375,6 +375,7 @@ void Context::cursorDown() {
 	cursorDown(false);
 }
 void Context::cursorDown(bool moveOnly) {
+	if (!moveOnly) cursorAutoNewline();
 	auto font = getFont();
 	if (cursorBehaviour.flipXY) {
 		activeCursor->X += (cursorBehaviour.invertHorizontal ? -font->width : font->width);


### PR DESCRIPTION
this ensures that scroll protect behaviour is the same as on RISC OS when cursor down is called when cursor is off the edge of the screen