### PR TITLE
Adding CRC16/32 verification to hexload

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -21,6 +21,7 @@ framework = arduino
 lib_deps =
     https://github.com/AgonConsole8/vdp-gl.git#dottedlines-arcs-etc
     fbiego/ESP32Time@^2.0.0
+    robtillaart/CRC@^1.0.3
 build_unflags = -Os
 build_flags =
     -O2


### PR DESCRIPTION
General overhaul of most of the hexload code.
New features
- Adding an extended mode, wrapping Intel Hex transport inside a per-record CRC16 check
- In extended mode, retransmit at CRC16 failure
- CRC32 verification at end of transmission
- For now, any single-bit error from the ez80<->VDP side of things will trigger a record retransmit. We'll update this when the RTS/CTS is done in future
- Escape key escapes out of a started hexload
- Incoming high-speed overruns are detected, frames discarded
- 'Normal' Intel hex files pass as usual, without any CRC checks

Tested from Windows/Linux with the new sender script at my agon-hexload repo. The hexload client needs no change.