### PR TITLE
add “print buffer” command

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -63,6 +63,7 @@
 #define VDP_READ_COLOUR			0x94	// Read colour
 #define VDP_FONT				0x95	// Font management commands
 #define VDP_CONTROLKEYS			0x98	// Control keys on/off
+#define VDP_BUFFER_PRINT		0x9B	// Print a buffer of characters literally with no command interpretation
 #define VDP_TEXT_VIEWPORT		0x9C	// Set text viewport using current graphics coordinates
 #define VDP_GRAPHICS_VIEWPORT	0x9D	// Set graphics viewport using current graphics coordinates
 #define VDP_GRAPHICS_ORIGIN		0x9E	// Set graphics origin using current graphics coordinates

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -61,6 +61,7 @@ class VDUStreamProcessor {
 		void sendScreenChar(char c);
 		void sendScreenPixel(uint16_t x, uint16_t y);
 		void sendColour(uint8_t colour);
+		void printBuffer(uint16_t bufferId);
 		void sendTime();
 		void vdu_sys_video_time();
 		void sendKeyboardState();


### PR DESCRIPTION
`VDU 23,0,&9B,bufferId;` will print a buffer out, using only the raw character values.  this bypasses VDU command processing, so no control characters at all are supported

addresses #217 