### PR TITLE
Transformed bitmap plots

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,8 @@ board_build.f_cpu = 240000000L
 board_build.f_flash = 80000000L
 framework = arduino
 lib_deps =
-    https://github.com/AgonConsole8/vdp-gl.git#dottedlines-arcs-etc
+    ; https://github.com/AgonConsole8/vdp-gl.git#dottedlines-arcs-etc
+    ../vdp-gl
     fbiego/ESP32Time@^2.0.0
     robtillaart/CRC@^1.0.3
 build_unflags = -Os
@@ -27,7 +28,7 @@ build_flags =
     -O2
     -DBOARD_HAS_PSRAM
     -mfix-esp32-psram-cache-issue
-; build_type = debug
+build_type = debug
 monitor_filters = esp32_exception_decoder
 monitor_speed = 115200
 upload_speed = 600000

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,8 +19,7 @@ board_build.f_cpu = 240000000L
 board_build.f_flash = 80000000L
 framework = arduino
 lib_deps =
-    ; https://github.com/AgonConsole8/vdp-gl.git#dottedlines-arcs-etc
-    ../vdp-gl
+    https://github.com/AgonConsole8/vdp-gl.git#transformed-bitmaps
     fbiego/ESP32Time@^2.0.0
     robtillaart/CRC@^1.0.3
 build_unflags = -Os
@@ -28,7 +27,7 @@ build_flags =
     -O2
     -DBOARD_HAS_PSRAM
     -mfix-esp32-psram-cache-issue
-build_type = debug
+; build_type = debug
 monitor_filters = esp32_exception_decoder
 monitor_speed = 115200
 upload_speed = 600000

--- a/video/agon.h
+++ b/video/agon.h
@@ -62,6 +62,7 @@
 #define VDP_SCRCHAR_GRAPHICS	0x93	// Character read from screen at graphics coordinates
 #define VDP_READ_COLOUR			0x94	// Read colour
 #define VDP_FONT				0x95	// Font management commands
+#define VDP_AFFINE_TRANSFORM	0x96	// Set affine transform
 #define VDP_CONTROLKEYS			0x98	// Control keys on/off
 #define VDP_BUFFER_PRINT		0x9B	// Print a buffer of characters literally with no command interpretation
 #define VDP_TEXT_VIEWPORT		0x9C	// Set text viewport using current graphics coordinates

--- a/video/agon.h
+++ b/video/agon.h
@@ -322,13 +322,15 @@
 // TODO think about numbers of arguments for each operation
 #define AFFINE_IDENTITY			0		// Create/reset to an identity matrix (no arguments)
 #define AFFINE_INVERT			1		// Invert (no arguments)
-#define AFFINE_ROTATE			2		// Rotate (1 argument)
-#define AFFINE_MULTIPLY			3		// Multiply (1 argument)
-#define AFFINE_SCALE			4		// Scale (2 arguments for X and Y)
-#define AFFINE_TRANSLATE		5		// Translate (X and Y)
-#define AFFINE_SHEAR			6		// Shear (2 arguments for X and Y)
-#define AFFINE_SKEW				7		// Skew (by angle, 2 arguments)
-#define AFFINE_TRANSFORM		8		// Combine in a transform matrix (6 arguments, last row automatically 0 0 1, or a buffer)
+#define AFFINE_ROTATE			2		// Rotate (anticlockwise by angle, 1 argument)
+#define AFFINE_ROTATE_RAD		3		// Rotate (anticlockwise by angle in radians, 1 argument)
+#define AFFINE_MULTIPLY			4		// Multiply (1 argument)
+#define AFFINE_SCALE			5		// Scale (2 arguments for X and Y)
+#define AFFINE_TRANSLATE		6		// Translate (X and Y)
+#define AFFINE_SHEAR			7		// Shear (2 arguments for X and Y)
+#define AFFINE_SKEW				8		// Skew (by angle, 2 arguments)
+#define AFFINE_SKEW_RAD			9		// Skew (by angle in radians, 2 arguments)
+#define AFFINE_TRANSFORM		10		// Combine in a transform matrix (6 arguments, last row automatically 0 0 1, or a buffer)
 
 #define AFFINE_OP_MASK			0x0F	// operation code mask
 #define AFFINE_OP_ADVANCED_OFFSETS	0x10	// advanced, 24-bit offsets (16-bit block offset follows if top bit set)

--- a/video/agon.h
+++ b/video/agon.h
@@ -327,10 +327,11 @@
 #define AFFINE_MULTIPLY			4		// Multiply (1 argument)
 #define AFFINE_SCALE			5		// Scale (2 arguments for X and Y)
 #define AFFINE_TRANSLATE		6		// Translate (X and Y)
-#define AFFINE_SHEAR			7		// Shear (2 arguments for X and Y)
-#define AFFINE_SKEW				8		// Skew (by angle, 2 arguments)
-#define AFFINE_SKEW_RAD			9		// Skew (by angle in radians, 2 arguments)
-#define AFFINE_TRANSFORM		10		// Combine in a transform matrix (6 arguments, last row automatically 0 0 1, or a buffer)
+#define AFFINE_TRANSLATE_OS_COORDS		7		// Translate (X and Y)
+#define AFFINE_SHEAR			8		// Shear (2 arguments for X and Y)
+#define AFFINE_SKEW				9		// Skew (by angle, 2 arguments)
+#define AFFINE_SKEW_RAD			10		// Skew (by angle in radians, 2 arguments)
+#define AFFINE_TRANSFORM		11		// Combine in a transform matrix (6 arguments, last row automatically 0 0 1, or a buffer)
 
 #define AFFINE_OP_MASK			0x0F	// operation code mask
 #define AFFINE_OP_ADVANCED_OFFSETS	0x10	// advanced, 24-bit offsets (16-bit block offset follows if top bit set)

--- a/video/agon.h
+++ b/video/agon.h
@@ -260,6 +260,8 @@
 #define BUFFERED_REVERSE				0x18	// Reverse the order of data in a buffer
 #define BUFFERED_COPY_REF				0x19	// Copy references to blocks from multiple buffers into one buffer
 #define BUFFERED_COPY_AND_CONSOLIDATE	0x1A	// Copy blocks from multiple buffers into one buffer and consolidate them
+#define BUFFERED_AFFINE_TRANSFORM		0x20	// Create or combine affine transform matrix buffer
+#define BUFFERED_AFFINE_TRANSFORM_APPLY	0x21	// Apply an affine transform matrix to a buffer
 #define BUFFERED_COMPRESS				0x40	// Compress blocks from multiple buffers into one buffer
 #define BUFFERED_DECOMPRESS				0x41	// Decompress blocks from multiple buffers into one buffer
 #define BUFFERED_EXPAND_BITMAP			0x48	// Expand a bitmap buffer
@@ -312,6 +314,36 @@
 #define EXPAND_BITMAP_SIZE		0x07	// bottom bits indicate the number of bits per pixel in bitmap, 0=8bpp
 #define EXPAND_BITMAP_ALIGNED	0x08	// includes pixel width value to indicate where a byte alignment should be performed
 #define EXPAND_BITMAP_USEBUFFER	0x10	// use buffer ID for mapping data
+
+// Affine transform operation codes
+// if applying to an empty buffer, generate a matrix with the given operation
+// otherwise combine the existing matrix with the given operation
+// TODO think about numbers of arguments for each operation
+#define AFFINE_IDENTITY			0		// Create/reset to an identity matrix (no arguments)
+#define AFFINE_INVERT			1		// Invert (no arguments)
+#define AFFINE_ROTATE			2		// Rotate (1 argument)
+#define AFFINE_MULTIPLY			3		// Multiply (1 argument)
+#define AFFINE_SCALE			4		// Scale (2 arguments for X and Y)
+#define AFFINE_TRANSLATE		5		// Translate (X and Y)
+#define AFFINE_SHEAR			6		// Shear (2 arguments for X and Y)
+#define AFFINE_SKEW				7		// Skew (by angle, 2 arguments)
+#define AFFINE_TRANSFORM		8		// Combine in a transform matrix (6 arguments, last row automatically 0 0 1, or a buffer)
+
+#define AFFINE_OP_MASK			0x0F	// operation code mask
+// Consider having flag to indicate separate args get separate formats?
+// or flag to indicate "no formats"??
+// also consider two versions of AFFINE_TRANSFORM, one with 6 arguments, one that's 9
+
+// Affine transform format flags byte
+// a format of 0 would indicate a 32-bit float value - "native" for transform matrix data
+// using a value of 0xC8 would indicate a 16-bit fixed point value with 8 bits of fractional part
+// a value of 0xC0 indicates 16-bit fixed point values with no fractional part
+#define AFFINE_FORMAT_SIZE_MASK	0x1F	// size bits (used for fixed point values)
+#define AFFINE_FORMAT_SIZE_TOPBIT	0x10	// top bit of size (used to work out if size is negative)
+#define AFFINE_FORMAT_FLAGS		0xE0	// flags
+#define AFFINE_FORMAT_FIXED		0x80	// if set, values are fixed-point, vs floats
+#define AFFINE_FORMAT_16BIT		0x40	// if set, values are 32-bit, vs 16-bit
+#define AFFINE_FORMAT_FROMBUFFER	0x20	// if set, values are fetched from a buffer, rather than as part of command
 
 // Buffered bitmap and sample info
 #define BUFFERED_BITMAP_BASEID	0xFA00	// Base ID for buffered bitmaps

--- a/video/agon.h
+++ b/video/agon.h
@@ -331,20 +331,18 @@
 #define AFFINE_TRANSFORM		8		// Combine in a transform matrix (6 arguments, last row automatically 0 0 1, or a buffer)
 
 #define AFFINE_OP_MASK			0x0F	// operation code mask
-// Consider having flag to indicate separate args get separate formats?
-// or flag to indicate "no formats"??
-// also consider two versions of AFFINE_TRANSFORM, one with 6 arguments, one that's 9
+#define AFFINE_OP_ADVANCED_OFFSETS	0x10	// advanced, 24-bit offsets (16-bit block offset follows if top bit set)
+#define AFFINE_OP_BUFFER_VALUE		0x20	// operand values are fetched from buffers
+#define AFFINE_OP_MULTI_FORMAT		0x40	// each argument has its own format byte
 
 // Affine transform format flags byte
 // a format of 0 would indicate a 32-bit float value - "native" for transform matrix data
-// using a value of 0xC8 would indicate a 16-bit fixed point value with 8 bits of fractional part
-// a value of 0xC0 indicates 16-bit fixed point values with no fractional part
-#define AFFINE_FORMAT_SIZE_MASK	0x1F	// size bits (used for fixed point values)
-#define AFFINE_FORMAT_SIZE_TOPBIT	0x10	// top bit of size (used to work out if size is negative)
+// using a value of 0xC7 would indicate a 16-bit fixed point value with the binary point shifted right 7 bits (for an 8/8 split)
+// a value of 0xCF indicates 16-bit fixed point values with no fractional part
+#define AFFINE_FORMAT_SHIFT_MASK	0x1F	// bits used for shift value (used for fixed point values)
 #define AFFINE_FORMAT_FLAGS		0xE0	// flags
-#define AFFINE_FORMAT_FIXED		0x80	// if set, values are fixed-point, vs floats
-#define AFFINE_FORMAT_16BIT		0x40	// if set, values are 32-bit, vs 16-bit
-#define AFFINE_FORMAT_FROMBUFFER	0x20	// if set, values are fetched from a buffer, rather than as part of command
+#define AFFINE_FORMAT_FIXED		0x40	// if set, values are fixed-point, vs floats
+#define AFFINE_FORMAT_16BIT		0x80	// if set, values are 16-bit, vs 32-bit
 
 // Buffered bitmap and sample info
 #define BUFFERED_BITMAP_BASEID	0xFA00	// Base ID for buffered bitmaps

--- a/video/agon.h
+++ b/video/agon.h
@@ -77,6 +77,8 @@
 #define VDP_CONTEXT				0xC8	// Context management commands
 #define VDP_FLUSH_DRAWING_QUEUE	0xCA	// Flush the drawing queue
 #define VDP_PATTERN_LENGTH		0xF2	// Set pattern length (*FX 163,242,n)
+#define VDP_TESTFLAG_SET		0xF8	// Set a test flag
+#define VDP_TESTFLAG_CLEAR		0xF9	// Clear a test flag
 #define VDP_CONSOLEMODE			0xFE	// Switch console mode on and off
 #define VDP_TERMINALMODE		0xFF	// Switch to terminal mode
 
@@ -351,6 +353,9 @@
 // Buffered bitmap and sample info
 #define BUFFERED_BITMAP_BASEID	0xFA00	// Base ID for buffered bitmaps
 #define BUFFERED_SAMPLE_BASEID	0xFB00	// Base ID for buffered samples
+
+// Test flags
+#define TEST_FLAG_AFFINE_TRANSFORM	1	// Affine transform test flag
 
 #define LOGICAL_SCRW			1280	// As per the BBC Micro standard
 #define LOGICAL_SCRH			1024

--- a/video/agon.h
+++ b/video/agon.h
@@ -343,6 +343,7 @@
 // using a value of 0xC7 would indicate a 16-bit fixed point value with the binary point shifted right 7 bits (for an 8/8 split)
 // a value of 0xCF indicates 16-bit fixed point values with no fractional part
 #define AFFINE_FORMAT_SHIFT_MASK	0x1F	// bits used for shift value (used for fixed point values)
+#define AFFINE_FORMAT_SHIFT_TOPBIT	0x10	// top bit of shift (used to work out if shift is negative)
 #define AFFINE_FORMAT_FLAGS		0xE0	// flags
 #define AFFINE_FORMAT_FIXED		0x40	// if set, values are fixed-point, vs floats
 #define AFFINE_FORMAT_16BIT		0x80	// if set, values are 16-bit, vs 32-bit

--- a/video/agon_screen.h
+++ b/video/agon_screen.h
@@ -173,8 +173,6 @@ bool updateVGAController(uint8_t colours) {
 	}
 	_VGAController = std::move(controller);		// Switch to the new controller
 	_VGAController->begin();					// And spin it up
-	_VGAController->enableBackgroundPrimitiveExecution(true);
-	_VGAController->enableBackgroundPrimitiveTimeout(false);
 
 	return true;
 }
@@ -200,6 +198,9 @@ int8_t changeResolution(uint8_t colours, const char * modeLine, bool doubleBuffe
 	} else {
 		debug_log("changeResolution: modeLine is null\n\r");
 	}
+
+	_VGAController->enableBackgroundPrimitiveExecution(true);
+	_VGAController->enableBackgroundPrimitiveTimeout(true);
 
 	canvas.reset(new fabgl::Canvas(_VGAController.get()));		// Create the new canvas
 	debug_log("after change of canvas...\n\r");

--- a/video/context.h
+++ b/video/context.h
@@ -91,6 +91,7 @@ class Context {
 		uint8_t			gfgc, gbgc, tfgc, tbgc;			// Logical colour values for graphics and text
 		uint8_t			lineThickness = 1;				// Line thickness
 		uint16_t		currentBitmap = BUFFERED_BITMAP_BASEID;	// Current bitmap ID
+		uint16_t		bitmapTransform = -1;			// Bitmap transform buffer ID
 		fabgl::LinePattern	linePattern = fabgl::LinePattern();				// Dotted line pattern
 		uint8_t			linePatternLength = 8;			// Dotted line pattern length
 		std::vector<uint16_t>	charToBitmap = std::vector<uint16_t>(255, 65535);	// character to bitmap mapping
@@ -270,6 +271,8 @@ class Context {
 		void plotBackspace();
 		void drawBitmap(uint16_t x, uint16_t y, bool compensateHeight, bool forceSet);
 		void drawCursor(Point p);
+
+		void setAffineTransform(uint8_t flags, uint16_t bufferId);
 
 		void cls();
 		void clg();

--- a/video/context.h
+++ b/video/context.h
@@ -132,7 +132,6 @@ class Context {
 		// Viewport management functions
 		Rect * getViewport(ViewportType type);
 		bool setTextViewport(Rect rect);
-		Point scale(int16_t X, int16_t Y);
 		Point invScale(Point p);
 
 		// Font management functions
@@ -230,6 +229,7 @@ class Context {
 		void setOrigin();
 		void shiftOrigin();
 		void setLogicalCoords(bool b);
+		Point scale(int16_t X, int16_t Y);
 		Point toCurrentCoordinates(int16_t X, int16_t Y);
 		Point toScreenCoordinates(int16_t X, int16_t Y);
 

--- a/video/context/graphics.h
+++ b/video/context/graphics.h
@@ -911,6 +911,7 @@ void Context::resetGraphicsOptions() {
 	setLineThickness(1);
 	setCurrentBitmap(BUFFERED_BITMAP_BASEID);
 	setDottedLinePatternLength(0);
+	setAffineTransform(255, -1);
 }
 
 void Context::resetGraphicsPositioning() {
@@ -937,6 +938,7 @@ void Context::reset() {
 	resetTextPainting();
 	resetGraphicsPositioning();
 	setLineThickness(1);
+	setAffineTransform(255, -1);
 	resetFonts();
 	resetTextCursor();
 }

--- a/video/context/graphics.h
+++ b/video/context/graphics.h
@@ -809,21 +809,14 @@ void Context::drawBitmap(uint16_t x, uint16_t y, bool compensateHeight, bool for
 				auto &transformBuffer = transformBufferIter->second;
 				if (transformBuffer.size() == 1 || transformBuffer[0]->size() >= (sizeof(float) * 9)) {
 					// we have a valid transform buffer
-					// auto transform = dspm::Mat((float *)transformBuffer[0]->getBuffer(), 3,3);
-					// auto transform = (float *)transformBuffer[0]->getBuffer();
+					// we need to add a translate transform to set the position
+					// TODO consider omitting the translate, and just send x,y to drawTransformedBitmap
 					float pos[9] = {
 						1.0f, 0.0f, (float)x,
 						0.0f, 1.0f, (float)((compensateHeight && logicalCoords) ? (y + 1 - bitmap->height) : y),
 						0.0f, 0.0f, 1.0f,
 					};
-
-					// make a translate matrix for our position
-					// auto pos = dspm::Mat::eye(3);
-					// pos(0,2) = x;
-					// pos(1,2) = (compensateHeight && logicalCoords) ? (y + 1 - bitmap->height) : y;
-					// pos(2,2) = 1.0f;
-					// transform = pos * transform;
-					float transform[9];
+					float transform[9];		// target matrix
 					dspm_mult_f32(pos, (float *)transformBuffer[0]->getBuffer(), transform, 3, 3, 3);
 
 					debug_log("drawBitmap: drawing bitmap %d with transform buffer %d\n\r", currentBitmap, bitmapTransform);
@@ -831,20 +824,7 @@ void Context::drawBitmap(uint16_t x, uint16_t y, bool compensateHeight, bool for
 					debug_log("drawBitmap: %f %f %f\n\r", transform[0], transform[1], transform[2]);
 					debug_log("drawBitmap: %f %f %f\n\r", transform[3], transform[4], transform[5]);
 					debug_log("drawBitmap: %f %f %f\n\r", transform[6], transform[7], transform[8]);
-					// debug_log("drawBitmap: %f %f %f\n\r", transform(0,0), transform(0,1), transform(0,2));
-					// debug_log("drawBitmap: %f %f %f\n\r", transform(1,0), transform(1,1), transform(1,2));
-					// debug_log("drawBitmap: %f %f %f\n\r", transform(2,0), transform(2,1), transform(2,2));
-					// float transformData[9] = {
-					// 	transform(0,0), transform(0,1), transform(0,2),
-					// 	transform(1,0), transform(1,1), transform(1,2),
-					// 	transform(2,0), transform(2,1), transform(2,2),
-					// };
-					// canvas->drawTransformedBitmap(bitmap.get(), transformData);
-					// canvas->waitCompletion(false);
 					canvas->drawTransformedBitmap(bitmap.get(), transform);
-					// TODO Remove this - Force queue to process in current thread
-					// works around crashing bug when drawing queue processed on vsync in ISR
-					canvas->waitCompletion(false);
 					return;
 				} else {
 					debug_log("drawBitmap: transform buffer %d has %d elements\n\r", bitmapTransform, transformBuffer.size());

--- a/video/context/graphics.h
+++ b/video/context/graphics.h
@@ -809,24 +809,42 @@ void Context::drawBitmap(uint16_t x, uint16_t y, bool compensateHeight, bool for
 				auto &transformBuffer = transformBufferIter->second;
 				if (transformBuffer.size() == 1 || transformBuffer[0]->size() >= (sizeof(float) * 9)) {
 					// we have a valid transform buffer
-					auto transform = dspm::Mat((float *)transformBuffer[0]->getBuffer(), 3,3);
+					// auto transform = dspm::Mat((float *)transformBuffer[0]->getBuffer(), 3,3);
+					// auto transform = (float *)transformBuffer[0]->getBuffer();
+					float pos[9] = {
+						1.0f, 0.0f, (float)x,
+						0.0f, 1.0f, (float)((compensateHeight && logicalCoords) ? (y + 1 - bitmap->height) : y),
+						0.0f, 0.0f, 1.0f,
+					};
+
 					// make a translate matrix for our position
-					auto pos = dspm::Mat::eye(3);
-					pos(0,2) = x;
-					pos(1,2) = (compensateHeight && logicalCoords) ? (y + 1 - bitmap->height) : y;
-					pos(2,2) = 1.0f;
-					transform = pos * transform;
+					// auto pos = dspm::Mat::eye(3);
+					// pos(0,2) = x;
+					// pos(1,2) = (compensateHeight && logicalCoords) ? (y + 1 - bitmap->height) : y;
+					// pos(2,2) = 1.0f;
+					// transform = pos * transform;
+					float transform[9];
+					dspm_mult_f32(pos, (float *)transformBuffer[0]->getBuffer(), transform, 3, 3, 3);
+
 					debug_log("drawBitmap: drawing bitmap %d with transform buffer %d\n\r", currentBitmap, bitmapTransform);
 					debug_log("drawBitmap: transform matrix\n\r");
-					debug_log("drawBitmap: %f %f %f\n\r", transform(0,0), transform(0,1), transform(0,2));
-					debug_log("drawBitmap: %f %f %f\n\r", transform(1,0), transform(1,1), transform(1,2));
-					debug_log("drawBitmap: %f %f %f\n\r", transform(2,0), transform(2,1), transform(2,2));
-					float transformData[9] = {
-						transform(0,0), transform(0,1), transform(0,2),
-						transform(1,0), transform(1,1), transform(1,2),
-						transform(2,0), transform(2,1), transform(2,2),
-					};
-					canvas->drawTransformedBitmap(bitmap.get(), transformData);
+					debug_log("drawBitmap: %f %f %f\n\r", transform[0], transform[1], transform[2]);
+					debug_log("drawBitmap: %f %f %f\n\r", transform[3], transform[4], transform[5]);
+					debug_log("drawBitmap: %f %f %f\n\r", transform[6], transform[7], transform[8]);
+					// debug_log("drawBitmap: %f %f %f\n\r", transform(0,0), transform(0,1), transform(0,2));
+					// debug_log("drawBitmap: %f %f %f\n\r", transform(1,0), transform(1,1), transform(1,2));
+					// debug_log("drawBitmap: %f %f %f\n\r", transform(2,0), transform(2,1), transform(2,2));
+					// float transformData[9] = {
+					// 	transform(0,0), transform(0,1), transform(0,2),
+					// 	transform(1,0), transform(1,1), transform(1,2),
+					// 	transform(2,0), transform(2,1), transform(2,2),
+					// };
+					// canvas->drawTransformedBitmap(bitmap.get(), transformData);
+					// canvas->waitCompletion(false);
+					canvas->drawTransformedBitmap(bitmap.get(), transform);
+					// TODO Remove this - Force queue to process in current thread
+					// works around crashing bug when drawing queue processed on vsync in ISR
+					canvas->waitCompletion(false);
 					return;
 				} else {
 					debug_log("drawBitmap: transform buffer %d has %d elements\n\r", bitmapTransform, transformBuffer.size());

--- a/video/context/viewport.h
+++ b/video/context/viewport.h
@@ -32,18 +32,9 @@ bool Context::setTextViewport(Rect r) {
 	return false;
 }
 
-// Scale a point, as appropriate for coordinate system
-//
-Point Context::scale(int16_t X, int16_t Y) {
-	if (logicalCoords) {
-		return Point((double)X / logicalScaleX, (double)Y / logicalScaleY);
-	}
-	return Point(X, Y);
-}
-
 Point Context::invScale(Point p) {
 	if (logicalCoords) {
-		return Point((double)p.X * logicalScaleX, (double)p.Y * logicalScaleY);
+		return Point((double)p.X * logicalScaleX, -(double)p.Y * logicalScaleY);
 	}
 	return p;
 }
@@ -123,13 +114,13 @@ void Context::setOrigin(int x, int y) {
 	auto newOrigin = scale(x, y);
 
 	if (logicalCoords) {
-		newOrigin.Y = canvasH - newOrigin.Y - 1;
+		newOrigin.Y = (canvasH - 1) + newOrigin.Y;
 	}
 
 	// shift up1 by the difference between the new and old origins, with scaling
 	auto delta = invScale(newOrigin.sub(origin));
 	up1.X = up1.X - delta.X;
-	up1.Y = logicalCoords ? up1.Y + delta.Y : up1.Y - delta.Y;
+	up1.Y = up1.Y - delta.Y;
 
 	origin = newOrigin;
 }
@@ -169,6 +160,15 @@ void Context::setLogicalCoords(bool b) {
 	}
 }
 
+// Scale a point, as appropriate for coordinate system
+//
+Point Context::scale(int16_t X, int16_t Y) {
+	if (logicalCoords) {
+		return Point((double)X / logicalScaleX, -(double)Y / logicalScaleY);
+	}
+	return Point(X, Y);
+}
+
 // Convert to currently active coordinate system
 //
 Point Context::toCurrentCoordinates(int16_t X, int16_t Y) {
@@ -185,7 +185,7 @@ Point Context::toCurrentCoordinates(int16_t X, int16_t Y) {
 inline Point Context::toScreenCoordinates(int16_t X, int16_t Y) {
 	auto p = scale(X, Y);
 
-	return Point(origin.X + p.X, logicalCoords ? origin.Y - p.Y : origin.Y + p.Y);
+	return Point(origin.X + p.X, origin.Y + p.Y);
 }
 
 #endif // CONTEXT_VIEWPORT_H

--- a/video/test_flags.h
+++ b/video/test_flags.h
@@ -1,0 +1,33 @@
+#ifndef TEST_FLAGS_H
+#define TEST_FLAGS_H
+
+#include <memory>
+#include <unordered_map>
+
+std::unordered_map<uint16_t, uint16_t> testFlags;	// Test flags
+
+inline void setTestFlag(uint16_t flag, uint16_t value) {
+	testFlags[flag] = value;
+}
+
+inline void clearTestFlag(uint16_t flag) {
+	auto flagIter = testFlags.find(flag);
+	if (flagIter != testFlags.end()) {
+		testFlags.erase(flagIter);
+	}
+}
+
+inline bool isTestFlagSet(uint16_t flag) {
+	auto flagIter = testFlags.find(flag);
+	return flagIter != testFlags.end();
+}
+
+inline uint16_t getTestFlag(uint16_t flag) {
+	auto flagIter = testFlags.find(flag);
+	if (flagIter != testFlags.end()) {
+		return flagIter->second;
+	}
+	return 0;
+}
+
+#endif // TEST_FLAGS_H

--- a/video/types.h
+++ b/video/types.h
@@ -170,3 +170,37 @@ std::shared_ptr<T> make_shared_psram_array(size_t size)
 	return std::allocate_shared<T>(allocator, size);
 }
 
+float float16ToFloat32(uint16_t h) {
+    uint32_t sign = ((h >> 15) & 1) << 31;
+    uint32_t exponent = ((h >> 10) & 0x1f);
+    uint32_t fraction = h & 0x3ff;
+
+    if (exponent == 0) {
+        if (fraction == 0) {
+            // Zero
+            return sign == 0 ? +0.0f : -0.0f;
+        } else {
+            // Subnormal number
+            while ((fraction & 0x400) == 0) {
+                fraction <<= 1;
+                exponent--;
+            }
+            exponent++;
+            fraction &= 0x3ff;
+        }
+    } else if (exponent == 31) {
+        if (fraction == 0) {
+            // Infinity
+            return sign == 0 ? +INFINITY : -INFINITY;
+        } else {
+            // NaN
+            return NAN;
+        }
+    }
+
+    exponent = (exponent + 127 - 15) << 23;
+    fraction <<= 13;
+
+    uint32_t f = sign | exponent | fraction;
+    return reinterpret_cast<float&>(f);
+}

--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -17,6 +17,7 @@
 #include "mem_helpers.h"
 #include "multi_buffer_stream.h"
 #include "sprites.h"
+#include "test_flags.h"
 #include "types.h"
 #include "vdu_stream_processor.h"
 
@@ -191,7 +192,9 @@ void IRAM_ATTR VDUStreamProcessor::vdu_sys_buffered() {
 			bufferCopyAndConsolidate(bufferId, sourceBufferIds);
 		}	break;
 		case BUFFERED_AFFINE_TRANSFORM: {
-			bufferAffineTransform(bufferId);
+			if (isTestFlagSet(TEST_FLAG_AFFINE_TRANSFORM)) {
+				bufferAffineTransform(bufferId);
+			}
 		}	break;
 		case BUFFERED_COMPRESS: {
 			auto sourceBufferId = readWord_t();

--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -22,7 +22,7 @@
 
 // VDU 23, 0, &A0, bufferId; command: Buffered command support
 //
-void VDUStreamProcessor::vdu_sys_buffered() {
+void IRAM_ATTR VDUStreamProcessor::vdu_sys_buffered() {
 	auto bufferId = readWord_t(); if (bufferId == -1) return;
 	auto command = readByte_t(); if (command == -1) return;
 

--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -1781,6 +1781,17 @@ void VDUStreamProcessor::bufferAffineTransform(uint16_t bufferId) {
 			transform[5] = translateXY[1];
 			transform[8] = 1.0f;
 		}	break;
+		case AFFINE_TRANSLATE_OS_COORDS: {
+			// translate by a given amount of pixels
+			float translateXY[2] = {0.0f, 0.0f};
+			if (!readMultipleArgs(translateXY, 2)) {
+				return;
+			}
+			auto scaled = context->scale(translateXY[0], translateXY[1]);
+			transform[2] = scaled.X;
+			transform[5] = scaled.Y;
+			transform[8] = 1.0f;
+		}	break;
 		case AFFINE_SHEAR: {
 			// shear by a given amount
 			float shearXY[2] = {0.0f, 0.0f};

--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -1727,13 +1727,15 @@ void VDUStreamProcessor::bufferAffineTransform(uint16_t bufferId) {
 			memcpy(transform, matrix.data, matrixSize);
 			replace = true;
 		}	break;
-		case AFFINE_ROTATE: {
+		case AFFINE_ROTATE:
+		case AFFINE_ROTATE_RAD:
+		{
 			// rotate anticlockwise (given inverted Y axis) by a given angle in degrees
 			float angle = readFloatArgument();
 			if (angle == INFINITY) {
 				return;
 			}
-			angle = DEG_TO_RAD * angle;
+			if (op == AFFINE_ROTATE) angle = DEG_TO_RAD * angle;
 			const auto cosAngle = cosf(angle);
 			const auto sinAngle = sinf(angle);
 			transform[0] = cosAngle;
@@ -1797,6 +1799,16 @@ void VDUStreamProcessor::bufferAffineTransform(uint16_t bufferId) {
 			}
 			transform[1] = tanf(DEG_TO_RAD * skewXY[0]);
 			transform[3] = tanf(DEG_TO_RAD * skewXY[1]);
+			transform[8] = 1.0f;
+		}	break;
+		case AFFINE_SKEW_RAD: {
+			// skew by a given amount (angle)
+			float skewXY[2] = {0.0f, 0.0f};
+			if (!readMultipleArgs(skewXY, 2)) {
+				return;
+			}
+			transform[1] = tanf(skewXY[0]);
+			transform[3] = tanf(skewXY[1]);
 			transform[8] = 1.0f;
 		}	break;
 		case AFFINE_TRANSFORM: {

--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -1593,8 +1593,6 @@ void VDUStreamProcessor::bufferAffineTransform(uint16_t bufferId) {
 		isFromBuffer = format & AFFINE_FORMAT_FROMBUFFER;
 		size = format & AFFINE_FORMAT_SIZE_MASK;
 		// ensure our size value obeys negation
-		// TODO consider whether we want to support negative fixed-point sizes
-		// this would create large numbers, which we may not actually need
 		if (size & AFFINE_FORMAT_SIZE_TOPBIT) {
 			// top bit was set, so it's a negative - so we need to set the top bits of the size
 			size = size | AFFINE_FORMAT_FLAGS;
@@ -1617,10 +1615,7 @@ void VDUStreamProcessor::bufferAffineTransform(uint16_t bufferId) {
 			// floating point value - size ignored
 			// if we're reading a 16-bit value, we need to convert to 32-bit float
 			if (is16Bit) {
-				debug_log("bufferAffineTransform: 16-bit float not supported\n\r");
-				// return INFINITY;
 				return float16ToFloat32(rawValue);
-				// return (float)(*(__fp16*)&(int16_t)rawValue);
 			}
 			// take our raw value and interpret its bits as a float
 			return *(float*)&rawValue;
@@ -1821,15 +1816,9 @@ void VDUStreamProcessor::bufferAffineTransform(uint16_t bufferId) {
 		float existing[9] = {0.0f};
 		if (readMatrixFromBuffer(bufferId, &existing)) {
 			// combine the two matrices together
-			// auto matrix = dspm::Mat(existing, 3, 3);
-			// auto newMatrix = dspm::Mat(transform, 3, 3);
-			// matrix = newMatrix * matrix;
-
 			float newTransform[9] = {0.0f};
 			dspm_mult_f32(transform, existing, newTransform, 3, 3, 3);
-
 			// copy data from matrix back to our working transform matrix
-			// memcpy(transform, matrix.data, matrixSize);
 			memcpy(transform, newTransform, matrixSize);
 		}
 	}
@@ -1842,23 +1831,6 @@ void VDUStreamProcessor::bufferAffineTransform(uint16_t bufferId) {
 	debug_log(" %f %f %f\n\r", transform[0], transform[1], transform[2]);
 	debug_log(" %f %f %f\n\r", transform[3], transform[4], transform[5]);
 	debug_log(" %f %f %f\n\r", transform[6], transform[7], transform[8]);
-
-	// dump the matrix
-	// auto matrix = dspm::Mat(transform, 3, 3);
-	// debug_log(" %f %f %f\n\r", matrix(0, 0), matrix(0, 1), matrix(0, 2));
-	// debug_log(" %f %f %f\n\r", matrix(1, 0), matrix(1, 1), matrix(1, 2));
-	// debug_log(" %f %f %f\n\r", matrix(2, 0), matrix(2, 1), matrix(2, 2));
-
-	// float pos[3] = {0.0f, 0.0f, 1.0f};
-	// auto posMatrix = dspm::Mat(pos, 3, 1);
-	// auto posMatrix = dspm::Mat(3, 1);
-	// posMatrix(0, 0) = 0.0f;
-	// posMatrix(1, 0) = 0.0f;
-	// posMatrix(2, 0) = 1.0f;
-	// auto transformed = matrix * posMatrix;
-
-	// debug_log("Transformed position\n\r");
-	// debug_log(" %f %f %f\n\r", transformed(0, 0), transformed(1, 0), transformed(2, 0));
 }
 
 

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -128,6 +128,7 @@ class VDUStreamProcessor {
 		void bufferReverse(uint16_t bufferId, uint8_t options);
 		void bufferCopyRef(uint16_t bufferId, tcb::span<const uint16_t> sourceBufferIds);
 		void bufferCopyAndConsolidate(uint16_t bufferId, tcb::span<const uint16_t> sourceBufferIds);
+		void bufferAffineTransform(uint16_t bufferId);
 		void bufferCompress(uint16_t bufferId, uint16_t sourceBufferId);
 		void bufferDecompress(uint16_t bufferId, uint16_t sourceBufferId);
 		void bufferExpandBitmap(uint16_t bufferId, uint8_t options, uint16_t sourceBufferId);

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -10,6 +10,7 @@
 #include "agon.h"
 #include "agon_ps2.h"
 #include "agon_screen.h"
+#include "test_flags.h"
 #include "vdu_audio.h"
 #include "vdu_buffered.h"
 #include "vdu_context.h"
@@ -237,6 +238,9 @@ void VDUStreamProcessor::vdu_sys_video() {
 			vdu_sys_font();				// Font management
 		}	break;
 		case VDP_AFFINE_TRANSFORM: {	// VDU 23, 0, &96, flags, bufferId;
+			if (!isTestFlagSet(TEST_FLAG_AFFINE_TRANSFORM)) {
+				return;
+			}
 			auto flags = readByte_t();	// Set affine transform flags
 			if (flags == -1) return;
 			auto bufferId = readWord_t();
@@ -318,6 +322,15 @@ void VDUStreamProcessor::vdu_sys_video() {
 			if (b >= 0) {
 				context->setDottedLinePatternLength(b);
 			}
+		}	break;
+		case VDP_TESTFLAG_SET: {		// VDU 23, 0, &F8, flag; value;
+			auto flag = readWord_t();	// Set a test flag
+			auto value = readWord_t();
+			setTestFlag(flag, value);
+		}	break;
+		case VDP_TESTFLAG_CLEAR: {		// VDU 23, 0, &F9, flag
+			auto flag = readWord_t();	// Clear a test flag
+			clearTestFlag(flag);
 		}	break;
 		case VDP_CONSOLEMODE: {			// VDU 23, 0, &FE, n
 			auto b = readByte_t();

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -236,6 +236,15 @@ void VDUStreamProcessor::vdu_sys_video() {
 		case VDP_FONT: {				// VDU 23, 0, &95, command, [bufferId;] [<args>]
 			vdu_sys_font();				// Font management
 		}	break;
+		case VDP_AFFINE_TRANSFORM: {	// VDU 23, 0, &96, flags, bufferId;
+			auto flags = readByte_t();	// Set affine transform flags
+			if (flags == -1) return;
+			auto bufferId = readWord_t();
+			if (bufferId >= 0) {
+				debug_log("vdu_sys_video: affine transform, flags %d, buffer %d\n\r", flags, bufferId);
+				context->setAffineTransform(flags, bufferId);
+			}
+		}	break;
 		case VDP_CONTROLKEYS: {			// VDU 23, 0, &98, n
 			auto b = readByte_t();		// Set control keys,  0 = off, 1 = on (default)
 			if (b >= 0) {


### PR DESCRIPTION
adds support for creating (and adjusting) 2d affine transform matrixes in buffers.  affine transforms supported include rotate, scale (with separate x and y scaling values), skew, shear, and translation

a transform to be set to apply to all bitmap plot operations.  this works for all bitmap formats* in all screen depths

 * the "native" bitmap format is not supported, but that format is not advised for use, as it works in a peculiar manner - in reality it is only used for sprites (restoring the background area), and for now sprites do not accept transforms

(for those interested, the crash on plotting bitmaps that had earlier been noted on this PR was caused by how the floating point unit and interrupts works.  the plotting actually worked in all screen modes except for single-buffered 64 colour modes, as those did not attempt to draw the bitmaps from inside an interrupt.)

support for affine transforms is experimental and the API is subject to change.  to allow for this feature to be integrated and released in the VDP a new command to "set test flag" has also been added
