### PR TITLE
use enum class where appropriate

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -366,7 +366,7 @@ void debug_log(const char *format, ...);
 
 // Terminal states
 //
-enum TerminalState {
+enum class TerminalState {
 	Disabled,
 	Disabling,
 	Enabling,

--- a/video/audio_channel.h
+++ b/video/audio_channel.h
@@ -12,7 +12,7 @@
 
 extern fabgl::SoundGenerator *soundGenerator;  // audio handling sub-system
 
-enum AudioState : uint8_t {	// Audio channel state
+enum class AudioState : uint8_t {	// Audio channel state
 	Idle = 0,				// currently idle/silent
 	Pending,				// note will be played next loop call
 	Playing,				// playing (passive)

--- a/video/context.h
+++ b/video/context.h
@@ -29,16 +29,16 @@ typedef union {
 	};
 } CursorBehaviour;
 
-enum CursorType : uint8_t {
-	TextCursor,
-	GraphicsCursor,
+enum class CursorType : uint8_t {
+	Text,
+	Graphics,
 };
 
-enum ViewportType : uint8_t {
-	TextViewport = 0,		// Text viewport
-	DefaultViewport,		// Default (whole screen) viewport
-	GraphicsViewport,		// Graphics viewport
-	ActiveViewport,			// Active viewport
+enum class ViewportType : uint8_t {
+	Text = 0,		// Text viewport
+	Default,		// Default (whole screen) viewport
+	Graphics,		// Graphics viewport
+	Active,			// Active viewport
 };
 
 

--- a/video/context/cursor.h
+++ b/video/context/cursor.h
@@ -256,17 +256,17 @@ inline bool Context::textCursorActive() {
 
 inline void Context::setActiveCursor(CursorType type) {
 	switch (type) {
-		case CursorType::TextCursor:
+		case CursorType::Text:
 			activeCursor = &textCursor;
 			changeFont(textFont, textFontData, 0);
 			setCharacterOverwrite(true);
-			setActiveViewport(ViewportType::TextViewport);
+			setActiveViewport(ViewportType::Text);
 			break;
-		case CursorType::GraphicsCursor:
+		case CursorType::Graphics:
 			activeCursor = &p1;
 			changeFont(graphicsFont, graphicsFontData, 0);
 			setCharacterOverwrite(false);
-			setActiveViewport(ViewportType::GraphicsViewport);
+			setActiveViewport(ViewportType::Graphics);
 			break;
 	}
 }
@@ -341,7 +341,7 @@ void Context::resetTextCursor() {
 	// reset text viewport
 	// and set the active viewport to text
 	textViewport =	Rect(0, 0, canvasW - 1, canvasH - 1);
-	setActiveCursor(CursorType::TextCursor);
+	setActiveCursor(CursorType::Text);
 
 	// cursor behaviour however is _not_ reset here
 	cursorHome();

--- a/video/context/graphics.h
+++ b/video/context/graphics.h
@@ -875,7 +875,7 @@ void Context::cls() {
 		canvas->setBrushColor(tbg);
 		canvas->setPaintOptions(tpo);
 		setClippingRect(textViewport);
-		clearViewport(ViewportType::TextViewport);
+		clearViewport(ViewportType::Text);
 	}
 	cursorHome();
 	setPagedMode(pagedMode);
@@ -889,7 +889,7 @@ void Context::clg() {
 		canvas->setBrushColor(gbg);
 		canvas->setPaintOptions(gpobg);
 		setClippingRect(graphicsViewport);
-		clearViewport(ViewportType::GraphicsViewport);
+		clearViewport(ViewportType::Graphics);
 	}
 	pushPoint(0, 0);		// Reset graphics cursor position (as per BBC Micro CLG)
 }

--- a/video/context/viewport.h
+++ b/video/context/viewport.h
@@ -12,10 +12,10 @@
 
 Rect * Context::getViewport(ViewportType type) {
 	switch (type) {
-		case ViewportType::TextViewport: return &textViewport;
-		case ViewportType::DefaultViewport: return &defaultViewport;
-		case ViewportType::GraphicsViewport: return &graphicsViewport;
-		case ViewportType::ActiveViewport: return activeViewport;
+		case ViewportType::Text: return &textViewport;
+		case ViewportType::Default: return &defaultViewport;
+		case ViewportType::Graphics: return &graphicsViewport;
+		case ViewportType::Active: return activeViewport;
 		default: return &defaultViewport;
 	}
 }

--- a/video/vdu.h
+++ b/video/vdu.h
@@ -72,12 +72,12 @@ void VDUStreamProcessor::vdu(uint8_t c, bool usePeek) {
 			break;
 		case 0x04:
 			// enable text cursor
-			context->setActiveCursor(CursorType::TextCursor);
+			context->setActiveCursor(CursorType::Text);
 			sendModeInformation();
 			break;
 		case 0x05:
 			// enable graphics cursor
-			context->setActiveCursor(CursorType::GraphicsCursor);
+			context->setActiveCursor(CursorType::Graphics);
 			sendModeInformation();
 			break;
 		case 0x06:


### PR DESCRIPTION
improves readability of some enums, and ensures that they’re appropriately namespaced