### PR TITLE
optimised print routine

### DIFF
--- a/video/context.h
+++ b/video/context.h
@@ -95,6 +95,7 @@ class Context {
 		fabgl::LinePattern	linePattern = fabgl::LinePattern();				// Dotted line pattern
 		uint8_t			linePatternLength = 8;			// Dotted line pattern length
 		std::vector<uint16_t>	charToBitmap = std::vector<uint16_t>(256, 65535);	// character to bitmap mapping
+		bool			plottingText = false;			// Are we currently plotting text?
 
 		bool			logicalCoords = true;			// Use BBC BASIC logical coordinates
 

--- a/video/context/cursor.h
+++ b/video/context/cursor.h
@@ -269,6 +269,7 @@ inline void Context::setActiveCursor(CursorType type) {
 			setActiveViewport(ViewportType::Graphics);
 			break;
 	}
+	plottingText = false;
 }
 
 inline void Context::setCursorBehaviour(uint8_t setting, uint8_t mask = 0xFF) {

--- a/video/vdu.h
+++ b/video/vdu.h
@@ -194,25 +194,25 @@ void VDUStreamProcessor::vdu_print(char c, bool usePeek) {
 	s += c;
 	// gather our string for printing
 	if (usePeek) {
-		auto limit = 39;
+		auto limit = 15;
 		while (--limit) {
 			if (!byteAvailable()) {
 				break;
 			}
-			auto next = peekByte_t(FAST_COMMS_TIMEOUT);
+			auto next = inputStream->peek();
 			if (next == 27) {
-				readByte_t();
+				inputStream->read();
 				if (consoleMode) {
 					DBGSerial.write(next);
 				}
-				next = readByte_t(FAST_COMMS_TIMEOUT);
+				next = readByte_t();
 				if (next == -1) {
 					break;
 				}
 				s += (char)next;
-			} else if (next != -1 && ((next >= 0x20 && next <= 0x7E) || (next >= 0x80 && next <= 0xFF))) {
+			} else if ((next >= 0x20 && next <= 0x7E) || (next >= 0x80 && next <= 0xFF)) {
 				s += (char)next;
-				readByte_t();
+				inputStream->read();
 			} else {
 				break;
 			}


### PR DESCRIPTION
primary change is to track when plotting text, meaning that canvas calls to set up for text plotting can be omitted

with this setup, it typically scores under 001000 on badapplebenchmark - scores down to 000E70 have been observed