### PR TITLE
More transform operations

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@ board_build.f_cpu = 240000000L
 board_build.f_flash = 80000000L
 framework = arduino
 lib_deps =
-    https://github.com/AgonConsole8/vdp-gl.git#transformed-bitmaps
+    https://github.com/AgonConsole8/vdp-gl.git#get-bitmap-pixel
     fbiego/ESP32Time@^2.0.0
     robtillaart/CRC@^1.0.3
 build_unflags = -Os

--- a/video/agon.h
+++ b/video/agon.h
@@ -400,6 +400,8 @@
 //
 void debug_log(const char *format, ...);
 
+void force_debug_log(const char *format, ...);
+
 // Terminal states
 //
 enum class TerminalState {

--- a/video/agon.h
+++ b/video/agon.h
@@ -264,7 +264,8 @@
 #define BUFFERED_COPY_REF				0x19	// Copy references to blocks from multiple buffers into one buffer
 #define BUFFERED_COPY_AND_CONSOLIDATE	0x1A	// Copy blocks from multiple buffers into one buffer and consolidate them
 #define BUFFERED_AFFINE_TRANSFORM		0x20	// Create or combine affine transform matrix buffer
-#define BUFFERED_AFFINE_TRANSFORM_APPLY	0x21	// Apply an affine transform matrix to a buffer
+#define BUFFERED_TRANSFORM_BITMAP		0x21	// Create a new bitmap from an existing one by applying a 2d transform
+#define BUFFERED_TRANSFORM_DATA			0x22	// Transform data using a 2d affine transform matrix
 #define BUFFERED_COMPRESS				0x40	// Compress blocks from multiple buffers into one buffer
 #define BUFFERED_DECOMPRESS				0x41	// Decompress blocks from multiple buffers into one buffer
 #define BUFFERED_EXPAND_BITMAP			0x48	// Expand a bitmap buffer
@@ -334,6 +335,7 @@
 #define AFFINE_SKEW				9		// Skew (by angle, 2 arguments)
 #define AFFINE_SKEW_RAD			10		// Skew (by angle in radians, 2 arguments)
 #define AFFINE_TRANSFORM		11		// Combine in a transform matrix (6 arguments, last row automatically 0 0 1, or a buffer)
+#define AFFINE_TRANSLATE_BITMAP	12		// Translate using bitmap size multiplier (X and Y)
 
 #define AFFINE_OP_MASK			0x0F	// operation code mask
 #define AFFINE_OP_ADVANCED_OFFSETS	0x10	// advanced, 24-bit offsets (16-bit block offset follows if top bit set)

--- a/video/agon.h
+++ b/video/agon.h
@@ -263,9 +263,11 @@
 #define BUFFERED_REVERSE				0x18	// Reverse the order of data in a buffer
 #define BUFFERED_COPY_REF				0x19	// Copy references to blocks from multiple buffers into one buffer
 #define BUFFERED_COPY_AND_CONSOLIDATE	0x1A	// Copy blocks from multiple buffers into one buffer and consolidate them
-#define BUFFERED_AFFINE_TRANSFORM		0x20	// Create or combine affine transform matrix buffer
-#define BUFFERED_TRANSFORM_BITMAP		0x21	// Create a new bitmap from an existing one by applying a 2d transform
-#define BUFFERED_TRANSFORM_DATA			0x22	// Transform data using a 2d affine transform matrix
+#define BUFFERED_AFFINE_TRANSFORM		0x20	// Create or combine a 3x3 2d affine transform matrix buffer
+#define BUFFERED_AFFINE_TRANSFORM_3D	0x21	// Create or combine a 4x4 3d affine transform matrix buffer
+#define BUFFERED_MATRIX					0x22	// Create or combine a matrix buffer of arbitrary dimensions
+#define BUFFERED_TRANSFORM_BITMAP		0x28	// Create a new bitmap from an existing one by applying a 2d transform
+#define BUFFERED_TRANSFORM_DATA			0x29	// Transform data using a 2d affine transform matrix
 #define BUFFERED_COMPRESS				0x40	// Compress blocks from multiple buffers into one buffer
 #define BUFFERED_DECOMPRESS				0x41	// Decompress blocks from multiple buffers into one buffer
 #define BUFFERED_EXPAND_BITMAP			0x48	// Expand a bitmap buffer
@@ -356,6 +358,9 @@
 #define TRANSFORM_BITMAP_RESIZE		0x01	// Resize
 #define TRANSFORM_BITMAP_EXPLICIT_SIZE	0x02	// Use an explicit size (width and height)
 #define TRANSFORM_BITMAP_TRANSLATE	0x04	// Translate
+
+// Transform data flags
+#define TRANSFORM_DATA_NO_PAD	0x01	// Data does not need padding
 
 // Buffered bitmap and sample info
 #define BUFFERED_BITMAP_BASEID	0xFA00	// Base ID for buffered bitmaps

--- a/video/agon.h
+++ b/video/agon.h
@@ -364,10 +364,10 @@
 #define MATRIX_MULTIPLY			6		// Multiply (target = source1 * source2)
 #define MATRIX_SCALAR_MULTIPLY	7		// Scalar multiply (target = source1 * scalar)
 #define MATRIX_SUBMATRIX		8		// Extract a submatrix
-// #define MATRIX_INSERT_ROW		9		// Insert a row
-// #define MATRIX_INSERT_COLUMN	10		// Insert a column
-// #define MATRIX_DELETE_ROW		11		// Delete a row
-// #define MATRIX_DELETE_COLUMN	12		// Delete a column
+#define MATRIX_INSERT_ROW		9		// Insert a row
+#define MATRIX_INSERT_COLUMN	10		// Insert a column
+#define MATRIX_DELETE_ROW		11		// Delete a row
+#define MATRIX_DELETE_COLUMN	12		// Delete a column
 
 #define MATRIX_OP_MASK			0x0F	// operation code mask
 #define MATRIX_OP_ADVANCED_OFFSETS	0x10	// advanced, 24-bit offsets (16-bit block offset follows if top bit set)

--- a/video/agon.h
+++ b/video/agon.h
@@ -327,32 +327,51 @@
 // TODO think about numbers of arguments for each operation
 #define AFFINE_IDENTITY			0		// Create/reset to an identity matrix (no arguments)
 #define AFFINE_INVERT			1		// Invert (no arguments)
-#define AFFINE_ROTATE			2		// Rotate (anticlockwise by angle, 1 argument)
-#define AFFINE_ROTATE_RAD		3		// Rotate (anticlockwise by angle in radians, 1 argument)
-#define AFFINE_MULTIPLY			4		// Multiply (1 argument)
-#define AFFINE_SCALE			5		// Scale (2 arguments for X and Y)
-#define AFFINE_TRANSLATE		6		// Translate (X and Y)
-#define AFFINE_TRANSLATE_OS_COORDS		7		// Translate (X and Y)
-#define AFFINE_SHEAR			8		// Shear (2 arguments for X and Y)
-#define AFFINE_SKEW				9		// Skew (by angle, 2 arguments)
-#define AFFINE_SKEW_RAD			10		// Skew (by angle in radians, 2 arguments)
-#define AFFINE_TRANSFORM		11		// Combine in a transform matrix (6 arguments, last row automatically 0 0 1, or a buffer)
-#define AFFINE_TRANSLATE_BITMAP	12		// Translate using bitmap size multiplier (X and Y)
+#define AFFINE_ROTATE			2		// Rotate (anticlockwise by angle, 1 argument for 2d, 3 arguments for 3d)
+#define AFFINE_ROTATE_RAD		3		// Rotate (anticlockwise by angle in radians, 1 argument for 2d, 3 arguments for 3d)
+#define AFFINE_MULTIPLY			4		// Scalar multiply (1 argument)
+#define AFFINE_SCALE			5		// Scale (1 argument per dimension for X, Y and Z)
+#define AFFINE_TRANSLATE		6		// Translate (1 argument per dimension)
+#define AFFINE_TRANSLATE_OS_COORDS		7		// Translate (1 argument per dimension, X and Y in OS coordinates, Z un-scaled)
+#define AFFINE_SHEAR			8		// Shear (1 argument per dimension)
+#define AFFINE_SKEW				9		// Skew (by angle, 1 argument per dimension)
+#define AFFINE_SKEW_RAD			10		// Skew (by angle in radians, 1 argument per dimension)
+#define AFFINE_TRANSFORM		11		// Combine in a transform matrix (6 arguments for 2d, 12 for 3d, last row automatically identity value, or a buffer)
+#define AFFINE_TRANSLATE_BITMAP	12		// Translate using bitmap size multiplier (X and Y only)
 
 #define AFFINE_OP_MASK			0x0F	// operation code mask
 #define AFFINE_OP_ADVANCED_OFFSETS	0x10	// advanced, 24-bit offsets (16-bit block offset follows if top bit set)
 #define AFFINE_OP_BUFFER_VALUE		0x20	// operand values are fetched from buffers
 #define AFFINE_OP_MULTI_FORMAT		0x40	// each argument has its own format byte
 
-// Affine transform format flags byte
+// Floating point value format byte
 // a format of 0 would indicate a 32-bit float value - "native" for transform matrix data
-// using a value of 0xC7 would indicate a 16-bit fixed point value with the binary point shifted right 7 bits (for an 8/8 split)
-// a value of 0xCF indicates 16-bit fixed point values with no fractional part
-#define AFFINE_FORMAT_SHIFT_MASK	0x1F	// bits used for shift value (used for fixed point values)
-#define AFFINE_FORMAT_SHIFT_TOPBIT	0x10	// top bit of shift (used to work out if shift is negative)
-#define AFFINE_FORMAT_FLAGS		0xE0	// flags
-#define AFFINE_FORMAT_FIXED		0x40	// if set, values are fixed-point, vs floats
-#define AFFINE_FORMAT_16BIT		0x80	// if set, values are 16-bit, vs 32-bit
+// using a value of 0xC8 would indicate a 16-bit fixed point value with the binary point shifted left 8 bits (for an 8/8 split)
+// a value of 0xC0 indicates 16-bit fixed point values with no fractional part
+#define FLOAT_FORMAT_SHIFT_MASK	0x1F	// bits used for shift value (used for fixed point values)
+#define FLOAT_FORMAT_SHIFT_TOPBIT	0x10	// top bit of shift (used to work out if shift is negative)
+#define FLOAT_FORMAT_FLAGS		0xE0	// flags
+#define FLOAT_FORMAT_FIXED		0x40	// if set, values are fixed-point, vs floats
+#define FLOAT_FORMAT_16BIT		0x80	// if set, values are 16-bit, vs 32-bit
+
+// Matrix operations
+#define MATRIX_SET				0		// Set a new matrix with given values
+#define MATRIX_SET_VALUE		1		// New matrix with single value set at row/column
+#define MATRIX_FILL				2		// Fill a matrix with a given value
+#define MATRIX_DIAGONAL			3		// Diagonal matrix from input values
+#define MATRIX_ADD				4		// Add matrixes (target = source1 + source2)
+#define MATRIX_SUBTRACT			5		// Subtract (target = source1 - source2)
+#define MATRIX_MULTIPLY			6		// Multiply (target = source1 * source2)
+#define MATRIX_SCALAR_MULTIPLY	7		// Scalar multiply (target = source1 * scalar)
+#define MATRIX_SUBMATRIX		8		// Extract a submatrix
+// #define MATRIX_INSERT_ROW		9		// Insert a row
+// #define MATRIX_INSERT_COLUMN	10		// Insert a column
+// #define MATRIX_DELETE_ROW		11		// Delete a row
+// #define MATRIX_DELETE_COLUMN	12		// Delete a column
+
+#define MATRIX_OP_MASK			0x0F	// operation code mask
+#define MATRIX_OP_ADVANCED_OFFSETS	0x10	// advanced, 24-bit offsets (16-bit block offset follows if top bit set)
+#define MATRIX_OP_BUFFER_VALUE	0x20	// operand values are fetched from buffers
 
 // Transform bitmap flags
 #define TRANSFORM_BITMAP_RESIZE		0x01	// Resize

--- a/video/agon.h
+++ b/video/agon.h
@@ -379,14 +379,13 @@
 #define TRANSFORM_BITMAP_TRANSLATE	0x04	// Translate
 
 // Transform data flags
-#define TRANSFORM_DATA_NO_PAD		0x01	// Data does not need padding
+#define TRANSFORM_DATA_HAS_SIZE		0x01	// Explicit size set (otherwise size = rows - 1)
 #define TRANSFORM_DATA_HAS_OFFSET	0x02	// Has an offset to the data
 #define TRANSFORM_DATA_HAS_STRIDE	0x04	// Has an explicit stride (in bytes) between value sets
 #define TRANSFORM_DATA_HAS_LIMIT	0x08	// Has a limited number of data items transformed
 #define TRANSFORM_DATA_ADVANCED		0x10	// Advanced offsets
-#define TRANSFORM_DATA_OFFSET_BUFF	0x20	// Offset value is buffer-fetched
-#define TRANSFORM_DATA_STRIDE_BUFF	0x40	// Stride value is buffer-fetched
-#define TRANSFORM_DATA_LIMIT_BUFF	0x80	// Limit value is buffer-fetched
+#define TRANSFORM_DATA_BUFFER_ARGS	0x20	// Optional argument values are fetched from buffers
+#define TRANSFORM_DATA_PER_BLOCK	0x40	// Transform data per block
 
 // Buffered bitmap and sample info
 #define BUFFERED_BITMAP_BASEID	0xFA00	// Base ID for buffered bitmaps

--- a/video/agon.h
+++ b/video/agon.h
@@ -352,6 +352,11 @@
 #define AFFINE_FORMAT_FIXED		0x40	// if set, values are fixed-point, vs floats
 #define AFFINE_FORMAT_16BIT		0x80	// if set, values are 16-bit, vs 32-bit
 
+// Transform bitmap flags
+#define TRANSFORM_BITMAP_RESIZE		0x01	// Resize
+#define TRANSFORM_BITMAP_EXPLICIT_SIZE	0x02	// Use an explicit size (width and height)
+#define TRANSFORM_BITMAP_TRANSLATE	0x04	// Translate
+
 // Buffered bitmap and sample info
 #define BUFFERED_BITMAP_BASEID	0xFA00	// Base ID for buffered bitmaps
 #define BUFFERED_SAMPLE_BASEID	0xFB00	// Base ID for buffered samples

--- a/video/agon.h
+++ b/video/agon.h
@@ -267,7 +267,7 @@
 #define BUFFERED_AFFINE_TRANSFORM_3D	0x21	// Create or combine a 4x4 3d affine transform matrix buffer
 #define BUFFERED_MATRIX					0x22	// Create or combine a matrix buffer of arbitrary dimensions
 #define BUFFERED_TRANSFORM_BITMAP		0x28	// Create a new bitmap from an existing one by applying a 2d transform
-#define BUFFERED_TRANSFORM_DATA			0x29	// Transform data using a 2d affine transform matrix
+#define BUFFERED_TRANSFORM_DATA			0x29	// Transform data using a given matrix
 #define BUFFERED_COMPRESS				0x40	// Compress blocks from multiple buffers into one buffer
 #define BUFFERED_DECOMPRESS				0x41	// Decompress blocks from multiple buffers into one buffer
 #define BUFFERED_EXPAND_BITMAP			0x48	// Expand a bitmap buffer
@@ -324,7 +324,6 @@
 // Affine transform operation codes
 // if applying to an empty buffer, generate a matrix with the given operation
 // otherwise combine the existing matrix with the given operation
-// TODO think about numbers of arguments for each operation
 #define AFFINE_IDENTITY			0		// Create/reset to an identity matrix (no arguments)
 #define AFFINE_INVERT			1		// Invert (no arguments)
 #define AFFINE_ROTATE			2		// Rotate (anticlockwise by angle, 1 argument for 2d, 3 arguments for 3d)

--- a/video/agon.h
+++ b/video/agon.h
@@ -360,7 +360,14 @@
 #define TRANSFORM_BITMAP_TRANSLATE	0x04	// Translate
 
 // Transform data flags
-#define TRANSFORM_DATA_NO_PAD	0x01	// Data does not need padding
+#define TRANSFORM_DATA_NO_PAD		0x01	// Data does not need padding
+#define TRANSFORM_DATA_HAS_OFFSET	0x02	// Has an offset to the data
+#define TRANSFORM_DATA_HAS_STRIDE	0x04	// Has an explicit stride (in bytes) between value sets
+#define TRANSFORM_DATA_HAS_LIMIT	0x08	// Has a limited number of data items transformed
+#define TRANSFORM_DATA_ADVANCED		0x10	// Advanced offsets
+#define TRANSFORM_DATA_OFFSET_BUFF	0x20	// Offset value is buffer-fetched
+#define TRANSFORM_DATA_STRIDE_BUFF	0x40	// Stride value is buffer-fetched
+#define TRANSFORM_DATA_LIMIT_BUFF	0x80	// Limit value is buffer-fetched
 
 // Buffered bitmap and sample info
 #define BUFFERED_BITMAP_BASEID	0xFA00	// Base ID for buffered bitmaps

--- a/video/agon_audio.h
+++ b/video/agon_audio.h
@@ -26,7 +26,10 @@ std::mutex soundGeneratorMutex;
 // audio channels and their associated tasks
 AudioChannel *audioChannels[MAX_AUDIO_CHANNELS];
 TaskHandle_t audioTask;
-std::unordered_map<uint16_t, std::shared_ptr<AudioSample>> samples;	// Storage for the sample data
+// Storage for our sample data
+std::unordered_map<uint16_t, std::shared_ptr<AudioSample>,
+	std::hash<uint16_t>, std::equal_to<uint16_t>,
+	psram_allocator<std::pair<const uint16_t, std::shared_ptr<AudioSample>>>> samples;
 fabgl::SoundGenerator *soundGenerator;  // audio handling sub-system
 
 bool channelEnabled(uint8_t channel);

--- a/video/agon_audio.h
+++ b/video/agon_audio.h
@@ -29,7 +29,6 @@ TaskHandle_t audioTask;
 std::unordered_map<uint16_t, std::shared_ptr<AudioSample>> samples;	// Storage for the sample data
 fabgl::SoundGenerator *soundGenerator;  // audio handling sub-system
 
-extern void force_debug_log(const char *format, ...);
 bool channelEnabled(uint8_t channel);
 
 // Audio channel driver task

--- a/video/agon_fonts.h
+++ b/video/agon_fonts.h
@@ -44,7 +44,9 @@
 #include "buffers.h"
 #include "types.h"
 
-std::unordered_map<uint16_t, std::shared_ptr<fabgl::FontInfo>> fonts;	// Storage for our fonts
+std::unordered_map<uint16_t, std::shared_ptr<fabgl::FontInfo>,
+	std::hash<uint16_t>, std::equal_to<uint16_t>,
+	psram_allocator<std::pair<const uint16_t, std::shared_ptr<fabgl::FontInfo>>>> fonts;	// Storage for our fonts
 
 uint8_t FONT_AGON_DATA[256*8]; 
 

--- a/video/audio_channel.h
+++ b/video/audio_channel.h
@@ -10,7 +10,7 @@
 #include "types.h"
 #include "envelopes/types.h"
 
-extern fabgl::SoundGenerator *soundGenerator;  // audio handling sub-system
+extern fabgl::SoundGenerator *soundGenerator; 	// audio handling sub-system
 
 enum class AudioState : uint8_t {	// Audio channel state
 	Idle = 0,				// currently idle/silent
@@ -43,11 +43,11 @@ class AudioChannel {
 		uint8_t		seekTo(uint32_t position);
 		void		loop(uint64_t now);
 		uint8_t		channel() { return _channel; }
-		void            goIdle();
+		void		goIdle();
 		std::unique_lock<std::mutex> lock() { return std::unique_lock<std::mutex>(_channelMutex); }
 	private:
 		uint8_t		_seekTo(uint32_t position);
-		void            _goIdle();
+		void		_goIdle();
 		WaveformGenerator *getSampleWaveform(uint16_t sampleId, AudioChannel *channelRef);
 		uint8_t		_getVolume(uint32_t elapsed);
 		uint16_t	_getFrequency(uint32_t elapsed);
@@ -61,14 +61,14 @@ class AudioChannel {
 		uint8_t		_waveformType;
 		AudioState	_state;
 		std::unique_ptr<WaveformGenerator>	_waveform;
-		std::mutex                              _channelMutex;
+		std::mutex							_channelMutex;
 		std::unique_ptr<VolumeEnvelope>		_volumeEnvelope;
 		std::unique_ptr<FrequencyEnvelope>	_frequencyEnvelope;
 };
 
 #include "audio_sample.h"
 #include "enhanced_samples_generator.h"
-extern std::unordered_map<uint16_t, std::shared_ptr<AudioSample>> samples;	// Storage for the sample data
+extern std::unordered_map<uint16_t, std::shared_ptr<AudioSample>, std::hash<uint16_t>, std::equal_to<uint16_t>, psram_allocator<std::pair<const uint16_t, std::shared_ptr<AudioSample>>>> samples;
 
 AudioChannel::AudioChannel(uint8_t channel) : _waveform(nullptr), _channel(channel), _state(AudioState::Idle), _volume(64), _frequency(750), _duration(-1) {
 	debug_log("AudioChannel: init %d\n\r", channel);

--- a/video/audio_sample.h
+++ b/video/audio_sample.h
@@ -5,11 +5,12 @@
 #include <unordered_map>
 
 #include "types.h"
+#include "buffers.h"
 #include "audio_channel.h"
 #include "buffer_stream.h"
 
 struct AudioSample {
-	AudioSample(std::vector<std::shared_ptr<BufferStream>> streams, uint8_t format, uint32_t sampleRate = AUDIO_DEFAULT_SAMPLE_RATE, uint16_t frequency = 0) :
+	AudioSample(BufferVector streams, uint8_t format, uint32_t sampleRate = AUDIO_DEFAULT_SAMPLE_RATE, uint16_t frequency = 0) :
 		blocks(streams), format(format), sampleRate(sampleRate), baseFrequency(frequency) {}
 	~AudioSample();
 
@@ -17,7 +18,7 @@ struct AudioSample {
 	void seekTo(uint32_t position, uint32_t & index, uint32_t & blockIndex, int32_t & repeatCount);
 	uint32_t getSize();
 
-	std::vector<std::shared_ptr<BufferStream>> blocks;
+	BufferVector	blocks;
 	uint8_t			format;				// Format of the sample data
 	uint32_t		sampleRate;			// Sample rate of the sample
 	uint16_t		baseFrequency = 0;	// Base frequency of the sample

--- a/video/buffer_stream.h
+++ b/video/buffer_stream.h
@@ -75,6 +75,9 @@ int BufferStream::peek() {
 }
 
 size_t BufferStream::readBytes(char * outBuffer, size_t length) {
+	if (bufferPosition >= bufferLength) {
+		return 0;
+	}
 	size_t readAmount = std::min<size_t>(length, available());
 	memcpy(outBuffer, &buffer[bufferPosition], readAmount);
 	bufferPosition += readAmount;

--- a/video/buffers.h
+++ b/video/buffers.h
@@ -11,8 +11,6 @@
 #include "span.h"
 #include "types.h"
 
-extern void debug_log(const char * format, ...);		// Debug log function
-
 using BufferVector = std::vector<std::shared_ptr<BufferStream>, psram_allocator<std::shared_ptr<BufferStream>>>;
 std::unordered_map<uint16_t, BufferVector, std::hash<uint16_t>, std::equal_to<uint16_t>, psram_allocator<std::pair<const uint16_t, BufferVector>>> buffers;
 

--- a/video/buffers.h
+++ b/video/buffers.h
@@ -6,6 +6,7 @@
 #include <unordered_map>
 #include <mat.h>
 
+#include "agon.h"
 #include "buffer_stream.h"
 #include "span.h"
 
@@ -153,5 +154,17 @@ bool checkTransformBuffer(std::vector<std::shared_ptr<BufferStream>> &transformB
 
 	return true;
 }
+
+void extractFormatInfo(uint8_t format, bool &isFixed, bool &is16Bit, int8_t &shift) {
+	isFixed = format & AFFINE_FORMAT_FIXED;
+	is16Bit = format & AFFINE_FORMAT_16BIT;
+	shift = format & AFFINE_FORMAT_SHIFT_MASK;
+	// ensure our size value obeys negation
+	if (is16Bit && (shift & AFFINE_FORMAT_SHIFT_TOPBIT)) {
+		// top bit was set, so it's a negative - so we need to set the top bits of the size
+		shift = shift | AFFINE_FORMAT_FLAGS;
+	}
+};
+
 
 #endif // BUFFERS_H

--- a/video/buffers.h
+++ b/video/buffers.h
@@ -156,13 +156,13 @@ bool checkTransformBuffer(std::vector<std::shared_ptr<BufferStream>> &transformB
 }
 
 void extractFormatInfo(uint8_t format, bool &isFixed, bool &is16Bit, int8_t &shift) {
-	isFixed = format & AFFINE_FORMAT_FIXED;
-	is16Bit = format & AFFINE_FORMAT_16BIT;
-	shift = format & AFFINE_FORMAT_SHIFT_MASK;
+	isFixed = format & FLOAT_FORMAT_FIXED;
+	is16Bit = format & FLOAT_FORMAT_16BIT;
+	shift = format & FLOAT_FORMAT_SHIFT_MASK;
 	// ensure our size value obeys negation
-	if (is16Bit && (shift & AFFINE_FORMAT_SHIFT_TOPBIT)) {
+	if (is16Bit && (shift & FLOAT_FORMAT_SHIFT_TOPBIT)) {
 		// top bit was set, so it's a negative - so we need to set the top bits of the size
-		shift = shift | AFFINE_FORMAT_FLAGS;
+		shift = shift | FLOAT_FORMAT_FLAGS;
 	}
 };
 

--- a/video/context/graphics.h
+++ b/video/context/graphics.h
@@ -820,19 +820,9 @@ void Context::drawBitmap(uint16_t x, uint16_t y, bool compensateHeight, bool for
 			auto transformBufferIter = buffers.find(bitmapTransform);
 			if (transformBufferIter != buffers.end()) {
 				auto &transformBuffer = transformBufferIter->second;
-				int const matrixSize = sizeof(float) * 9;
-				if (transformBuffer.size() == 1) {
-					// make sure we have an inverse matrix cached
-					if (transformBuffer[0]->size() < matrixSize) {
-						debug_log("drawBitmap: transform buffer %d has %d elements\n\r", bitmapTransform, transformBuffer[0]->size());
-						return;
-					}
-					// create an inverse matrix, and push that to the buffer
-					auto transform = (float *)transformBuffer[0]->getBuffer();
-					auto matrix = dspm::Mat(transform, 3, 3).inverse();
-					auto bufferStream = make_shared_psram<BufferStream>(matrixSize);
-					bufferStream->writeBuffer((uint8_t *)matrix.data, matrixSize);
-					transformBuffer.push_back(bufferStream);
+				if (!checkTransformBuffer(transformBuffer)) {
+					debug_log("drawBitmap: transform buffer %d is invalid\n\r", bitmapTransform);
+					return;
 				}
 				// NB: if we're drawing via PLOT and are using OS coords, then we _should_ be using bottom left of bitmap as our "origin" for transforms
 				// however we're not doing that here - the origin for transforms is top left of the bitmap

--- a/video/multi_buffer_stream.h
+++ b/video/multi_buffer_stream.h
@@ -10,7 +10,7 @@
 
 class MultiBufferStream : public Stream {
 	public:
-		MultiBufferStream(std::vector<std::shared_ptr<BufferStream>> buffers);
+		MultiBufferStream(BufferVector buffers);
 		int available();
 		int read();
 		int peek();
@@ -22,14 +22,14 @@ class MultiBufferStream : public Stream {
 		void rewind(size_t bufferIndex = 0);
 		void seekTo(uint32_t position, size_t bufferIndex = 0);
 		uint32_t size();
-		const std::vector<std::shared_ptr<BufferStream>> &tellBuffer(uint32_t &blockOffset, size_t &blockIndex);
+		const BufferVector &tellBuffer(uint32_t &blockOffset, size_t &blockIndex);
 	private:
-		std::vector<std::shared_ptr<BufferStream>> buffers;
+		BufferVector buffers;
 		BufferStream * getBuffer();
 		size_t currentBufferIndex = 0;
 };
 
-MultiBufferStream::MultiBufferStream(std::vector<std::shared_ptr<BufferStream>> buffers) : buffers(std::move(buffers)) {
+MultiBufferStream::MultiBufferStream(BufferVector buffers) : buffers(std::move(buffers)) {
 	// rewind to the start of the first buffer
 	rewind();
 }
@@ -106,7 +106,7 @@ uint32_t MultiBufferStream::size() {
 	return totalSize;
 }
 
-const std::vector<std::shared_ptr<BufferStream>> &MultiBufferStream::tellBuffer(uint32_t &blockOffset, size_t &blockIndex) {
+const BufferVector &MultiBufferStream::tellBuffer(uint32_t &blockOffset, size_t &blockIndex) {
 	auto buffer = getBuffer();
 	blockOffset = buffer ? buffer->tell() : 0;
 	blockIndex = currentBufferIndex;

--- a/video/sprites.h
+++ b/video/sprites.h
@@ -12,14 +12,17 @@
 #include "agon.h"
 #include "agon_ps2.h"
 #include "agon_screen.h"
+#include "types.h"
 
-std::unordered_map<uint16_t, std::shared_ptr<Bitmap>> bitmaps;	// Storage for our bitmaps
+std::unordered_map<uint16_t, std::shared_ptr<Bitmap>,
+	std::hash<uint16_t>, std::equal_to<uint16_t>,
+	psram_allocator<std::pair<const uint16_t, std::shared_ptr<Bitmap>>>> bitmaps;	// Storage for our bitmaps
 uint8_t			numsprites = 0;					// Number of sprites on stage
 uint8_t			current_sprite = 0;				// Current sprite number
 Sprite			sprites[MAX_SPRITES];			// Sprite object storage
 
 // track which sprites may be using a bitmap
-std::unordered_map<uint16_t, std::vector<uint8_t>> bitmapUsers;
+std::unordered_map<uint16_t, std::vector<uint8_t, psram_allocator<uint8_t>>> bitmapUsers;
 
 std::unordered_map<uint16_t, fabgl::Cursor> cursors;	// Storage for our cursors
 uint16_t		mCursor = MOUSE_DEFAULT_CURSOR;	// Mouse cursor

--- a/video/types.h
+++ b/video/types.h
@@ -208,15 +208,6 @@ float float16ToFloat32(uint16_t h) {
     return reinterpret_cast<float&>(f);
 }
 
-// uint16_t float32ToFloat16(const float x) { // IEEE-754 16-bit floating-point format (without infinity): 1-5-10, exp-15, +-131008.0, +-6.1035156E-5, +-5.9604645E-8, 3.311 digits
-//     const uint b = (*(uint*)&x)+0x00001000; // round-to-nearest-even: add last bit after truncated mantissa
-//     const uint e = (b&0x7F800000)>>23; // exponent
-//     const uint m = b&0x007FFFFF; // mantissa; in line below: 0x007FF000 = 0x00800000-0x00001000 = decimal indicator flag - initial rounding
-//     return (b&0x80000000)>>16 | (e>112)*((((e-112)<<10)&0x7C00)|m>>13) | ((e<113)&(e>101))*((((0x007FF000+m)>>(125-e))+1)>>1) | (e>143)*0x7FFF; // sign : normalized : denormalized : saturate
-// }
-
-
-
 uint16_t float32ToFloat16(float h) {
 	uint32_t f = reinterpret_cast<uint32_t&>(h);
 	uint32_t sign = (f >> 31) & 0x8000;

--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -1847,6 +1847,26 @@ void VDUStreamProcessor::bufferAffineTransform(uint16_t bufferId) {
 			}
 			transform[8] = 1.0f;
 		}	break;
+		case AFFINE_TRANSLATE_BITMAP: {
+			// translates by amounts proportional to width and height of bitmap
+			// first argument is a 16-bit bitmap ID
+			auto bitmapId = readWord_t();
+			if (bitmapId == -1) {
+				return;
+			}
+			float translateXY[2] = {0.0f, 0.0f};
+			if (!readMultipleArgs(translateXY, 2)) {
+				return;
+			}
+			auto bitmap = getBitmap(bitmapId);
+			if (!bitmap) {
+				debug_log("bufferAffineTransform: bitmap %d not found\n\r", bitmapId);
+				return;
+			}
+			transform[2] = translateXY[0] * bitmap->width;
+			transform[5] = translateXY[1] * bitmap->height;
+			transform[8] = 1.0f;
+		}	break;
 		default:
 			debug_log("bufferAffineTransform: unknown operation %d\n\r", op);
 			return;

--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -247,7 +247,7 @@ void IRAM_ATTR VDUStreamProcessor::vdu_sys_buffered() {
 		}	break;
 		case BUFFERED_DEBUG_INFO: {
 			// force_debug_log("vdu_sys_buffered: debug info stack highwater %d\n\r",uxTaskGetStackHighWaterMark(nullptr));
-			debug_log("vdu_sys_buffered: buffer %d, %d streams stored\n\r", bufferId, buffers[bufferId].size());
+			force_debug_log("vdu_sys_buffered: buffer %d, %d streams stored\n\r", bufferId, buffers[bufferId].size());
 			if (buffers[bufferId].empty()) {
 				return;
 			}
@@ -255,12 +255,12 @@ void IRAM_ATTR VDUStreamProcessor::vdu_sys_buffered() {
 			if (matrixSize.value != 0) {
 				float transform[matrixSize.size()] = {0.0f};
 				if (getMatrixFromBuffer(bufferId, transform, matrixSize)) {
-					debug_log("buffer contains a %d x %d matrix with contents:\n\r", matrixSize.rows, matrixSize.columns);
+					force_debug_log("buffer contains a %d x %d matrix with contents:\n\r", matrixSize.rows, matrixSize.columns);
 					for (int i = 0; i < matrixSize.rows; i++) {
 						for (int j = 0; j < matrixSize.columns; j++) {
-							debug_log(" %f", transform[i * matrixSize.columns + j]);
+							force_debug_log(" %f", transform[i * matrixSize.columns + j]);
 						}
-						debug_log("\n\r");
+						force_debug_log("\n\r");
 					}
 					return;
 				}
@@ -270,9 +270,9 @@ void IRAM_ATTR VDUStreamProcessor::vdu_sys_buffered() {
 			auto bufferLength = buffer->size();
 			for (auto i = 0; i < bufferLength; i++) {
 				auto data = buffer->getBuffer()[i];
-				debug_log("%02X ", data);
+				force_debug_log("%02X ", data);
 			}
-			debug_log("\n\r");
+			force_debug_log("\n\r");
 		}	break;
 		default: {
 			debug_log("vdu_sys_buffered: unknown command %d, buffer %d\n\r", command, bufferId);

--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -1992,7 +1992,9 @@ void VDUStreamProcessor::bufferTransformBitmap(uint16_t bufferId, uint8_t option
 
 	// NB source bitmap is currently assumed to be RGBA2222 format
 	auto srcWidth = bitmap->width;
+	float srcWidthF = (float)srcWidth;
 	auto srcHeight = bitmap->height;
+	float srcHeightF = (float)srcHeight;
 
 	auto transformBufferIter = buffers.find(transformBufferId);
 	if (transformBufferIter == buffers.end()) {
@@ -2033,14 +2035,14 @@ void VDUStreamProcessor::bufferTransformBitmap(uint16_t bufferId, uint8_t option
 		maxX = fabgl::imax(maxX, (int)transformed[0]);
 		maxY = fabgl::imax(maxY, (int)transformed[1]);
 
-		pos[0] = (float)srcWidth;
+		pos[0] = srcWidthF;
 		dspm_mult_3x3x1_f32(transform, pos, transformed);
 		minX = fabgl::imin(minX, (int)transformed[0]);
 		minY = fabgl::imin(minY, (int)transformed[1]);
 		maxX = fabgl::imax(maxX, (int)transformed[0]);
 		maxY = fabgl::imax(maxY, (int)transformed[1]);
 
-		pos[1] = (float)srcHeight;
+		pos[1] = srcHeightF;
 		dspm_mult_3x3x1_f32(transform, pos, transformed);
 		minX = fabgl::imin(minX, (int)transformed[0]);
 		minY = fabgl::imin(minY, (int)transformed[1]);
@@ -2094,13 +2096,10 @@ void VDUStreamProcessor::bufferTransformBitmap(uint16_t bufferId, uint8_t option
 			dspm_mult_3x3x1_f32(inverse, pos, srcPos);
 
 			auto srcPixel = 0;
-			int srcX = (int)srcPos[0];
-			int srcY = (int)srcPos[1];
-
-			if (srcX >= 0 && srcX < srcWidth && srcY >= 0 && srcY < srcHeight) {
+			if (srcPos[0] >= 0.0f && srcPos[0] < srcWidthF && srcPos[1] >= 0.0f && srcPos[1] < srcHeightF) {
 				// get the source pixel
 				// NB this currently assumes source is RGBA2222 format
-				auto src = source + srcY * srcWidth + srcX;
+				auto src = source + (int)srcPos[1] * srcWidth + (int)srcPos[0];
 				srcPixel = *src;
 			}
 			destination[(int)y * width + (int)x] = srcPixel;

--- a/video/vdu_context.h
+++ b/video/vdu_context.h
@@ -74,7 +74,7 @@ void VDUStreamProcessor::selectContext(uint8_t id) {
 	} else {
 		debug_log("selectContext: creating new context %d\n\r", id);
 		// copy current stack
-		auto newStack = make_shared_psram<std::vector<std::shared_ptr<Context>>>();
+		auto newStack = make_shared_psram<ContextVector>();
 		for (auto it = contextStack->begin(); it != contextStack->end(); ++it) {
 			newStack->push_back(make_shared_psram<Context>(*it->get()));
 		}

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -132,9 +132,8 @@ class VDUStreamProcessor {
 		void bufferReverse(uint16_t bufferId, uint8_t options);
 		void bufferCopyRef(uint16_t bufferId, tcb::span<const uint16_t> sourceBufferIds);
 		void bufferCopyAndConsolidate(uint16_t bufferId, tcb::span<const uint16_t> sourceBufferIds);
-		void bufferAffineTransform(uint16_t bufferId);
+		void bufferAffineTransform(uint16_t bufferId, bool is3D);
 		void bufferTransformBitmap(uint16_t bufferId, uint8_t options, uint16_t transformBufferId, uint16_t sourceBufferId);
-		// void bufferTransformData(uint16_t bufferId, uint8_t options, uint16_t offset, uint16_t stride, uint8_t format, uint16_t transformBufferId, uint16_t sourceBufferId);
 		void bufferTransformData(uint16_t bufferId, uint8_t options, uint8_t format, uint16_t transformBufferId, uint16_t sourceBufferId);
 		void bufferCompress(uint16_t bufferId, uint16_t sourceBufferId);
 		void bufferDecompress(uint16_t bufferId, uint16_t sourceBufferId);

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -9,6 +9,7 @@
 #include <fabgl.h>
 
 #include "agon.h"
+#include "buffers.h"
 #include "context.h"
 #include "buffer_stream.h"
 #include "span.h"
@@ -22,11 +23,6 @@ std::unordered_map<uint16_t, ContextVectorPtr,
 
 class VDUStreamProcessor {
 	private:
-		struct AdvancedOffset {
-			uint32_t blockOffset = 0;
-			size_t blockIndex = 0;
-		};
-
 		std::shared_ptr<Stream> inputStream;
 		std::shared_ptr<Stream> outputStream;
 		std::shared_ptr<Stream> originalOutputStream;
@@ -118,12 +114,6 @@ class VDUStreamProcessor {
 		void setOutputStream(uint16_t bufferId);
 		AdvancedOffset getOffsetFromStream(bool isAdvanced);
 		std::vector<uint16_t> getBufferIdsFromStream();
-		static tcb::span<uint8_t> getBufferSpan(const BufferVector &buffer, AdvancedOffset &offset, uint8_t size = 1);
-		static tcb::span<uint8_t> getBufferSpan(uint16_t bufferId, AdvancedOffset &offset, uint8_t size = 1);
-		static int16_t getBufferByte(const BufferVector &buffer, AdvancedOffset &offset, bool iterate = false);
-		static bool readBufferBytes(uint16_t bufferId, AdvancedOffset &offset, void *target, uint16_t size, bool iterate = false);
-		static float readBufferFloat(uint32_t sourceBufferId, AdvancedOffset &offset, bool is16Bit, bool isFixed, int8_t shift, bool iterate = false);
-		static bool setBufferByte(uint8_t value, const BufferVector &buffer, AdvancedOffset &offset, bool iterate = false);
 		void bufferAdjust(uint16_t bufferId);
 		bool bufferConditional();
 		void bufferJump(uint16_t bufferId, AdvancedOffset offset);
@@ -138,7 +128,7 @@ class VDUStreamProcessor {
 		void bufferCopyRef(uint16_t bufferId, tcb::span<const uint16_t> sourceBufferIds);
 		void bufferCopyAndConsolidate(uint16_t bufferId, tcb::span<const uint16_t> sourceBufferIds);
 		void bufferAffineTransform(uint16_t bufferId, uint8_t command, bool is3D);
-		void bufferMatrixManipulate(uint16_t bufferId, uint8_t command, uint8_t rows, uint8_t columns);
+		void bufferMatrixManipulate(uint16_t bufferId, uint8_t command, MatrixSize size);
 		void bufferTransformBitmap(uint16_t bufferId, uint8_t options, uint16_t transformBufferId, uint16_t sourceBufferId);
 		void bufferTransformData(uint16_t bufferId, uint8_t options, uint8_t format, uint16_t transformBufferId, uint16_t sourceBufferId);
 		void bufferCompress(uint16_t bufferId, uint16_t sourceBufferId);

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -129,6 +129,7 @@ class VDUStreamProcessor {
 		void bufferCopyRef(uint16_t bufferId, tcb::span<const uint16_t> sourceBufferIds);
 		void bufferCopyAndConsolidate(uint16_t bufferId, tcb::span<const uint16_t> sourceBufferIds);
 		void bufferAffineTransform(uint16_t bufferId);
+		void bufferTransformBitmap(uint16_t bufferId, uint8_t options, uint16_t transformBufferId, uint16_t sourceBufferId);
 		void bufferCompress(uint16_t bufferId, uint16_t sourceBufferId);
 		void bufferDecompress(uint16_t bufferId, uint16_t sourceBufferId);
 		void bufferExpandBitmap(uint16_t bufferId, uint8_t options, uint16_t sourceBufferId);

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -130,6 +130,7 @@ class VDUStreamProcessor {
 		void bufferCopyAndConsolidate(uint16_t bufferId, tcb::span<const uint16_t> sourceBufferIds);
 		void bufferAffineTransform(uint16_t bufferId);
 		void bufferTransformBitmap(uint16_t bufferId, uint8_t options, uint16_t transformBufferId, uint16_t sourceBufferId);
+		void bufferTransformData(uint16_t bufferId, uint8_t options, uint16_t offset, uint16_t stride, uint8_t format, uint16_t transformBufferId, uint16_t sourceBufferId);
 		void bufferCompress(uint16_t bufferId, uint16_t sourceBufferId);
 		void bufferDecompress(uint16_t bufferId, uint16_t sourceBufferId);
 		void bufferExpandBitmap(uint16_t bufferId, uint8_t options, uint16_t sourceBufferId);


### PR DESCRIPTION
Adds in a few new matrix operation commands

Affine transform command gains a "translate by bitmap size" operation, which adds an x,y translate to the transform where the given x and y values are scaled by the given bitmap's width and height.  this is useful for adding in translate ops that are proportional to bitmap size, such as translating to negative half width and half height to centre the transform origin

New 3d affine transform command added.  this supports all of the same options as the 2d affine transform command, and will create a 4x4 affine transform matrix.  3d versions generally take 1 more argument, as they need arguments for a third dimension.  rotate for 3d takes 3 arguments (instead of 1) to rotate around all 3 axes

Generic "matrix manipulate" command added, which allows matrixes of arbitrary dimensions to so be created (given as arguments to the command) and manipulated.  Operations include set, set value (to set an individual value at a row/column in an existing matrix), fill whole matrix with a given value, set values on the diagonal, add, subtract, multiply, scalar multiply, extract a sub-matrix, insert/delete row/column

New command added to create a new transformed bitmap.  This will take a source bitmap (of any supported format) and a transform buffer, and from those two it generates a new RGBA2222 format bitmap in the target buffer.  It accepts options to automatically resize the new bitmap to fit the transformed image, explicitly set the new size, and automatically translate the new bitmap back to the origin

New command to "transform data" added, which will take a source buffer, a matrix, and various options to control how data is found and interpreted.  The target buffer is a copy of the source with the matrix applied to it, given the options, so data within that buffer is transformed to new values.  As an example, if you have a buffer that contains a list of plot commands, this can be used to transform the coordinates given as part of those plot commands.  This can also be used to transform buffers of other data.  The data source format is specified as part of the command, and can be 16 or 32 bit values, that are fixed-point or floating-point values.  (Integer transforms are supported by using fixed-point format with a shift of zero)

Other changes include some reductions on internal memory requirements, which can help with the availability of screen modes when using buffers.