### PR TITLE
Add PlatformIO CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: PlatformIO CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+      - name: Build PlatformIO Project
+        run: pio run


### PR DESCRIPTION
A very simple addition, modelled after [the documentation](https://docs.platformio.org/en/latest/integration/ci/github-actions.html). Builds the firmware with PlatformIO on Windows, Linux and Mac to make sure it compiles fine on all platforms. Uses free Github CI runners.

For run logs see: https://github.com/maxgerhardt/agon-vdp/actions/runs/9587805332

Gives commits starting from the the nice green checkmark! :) 