### PR TITLE
fix MultiBufferStream read and peek

### DIFF
--- a/video/multi_buffer_stream.h
+++ b/video/multi_buffer_stream.h
@@ -44,12 +44,18 @@ int MultiBufferStream::available() {
 
 int MultiBufferStream::read() {
 	auto buffer = getBuffer();
-	return buffer->read();
+	if (buffer) {
+		return buffer->read();
+	}
+	return -1;
 }
 
 int MultiBufferStream::peek() {
 	auto buffer = getBuffer();
-	return buffer->peek();
+	if (buffer) {
+		return buffer->peek();
+	}
+	return -1;
 }
 
 size_t MultiBufferStream::readBytes(char * outBuffer, size_t length) {


### PR DESCRIPTION
ensure that calls to `read` and `peek` will return -1 if there is there isn’t a currently valid buffer block in MultiBufferStream

this fixes an issue where calling a buffer that ends with an incomplete VDU command would cause the VDP to fatally crash

Fixes #241 