### PR TITLE
Fixes dropped characters in console mode

### DIFF
--- a/video/vdu.h
+++ b/video/vdu.h
@@ -216,7 +216,7 @@ void VDUStreamProcessor::vdu_print(char c, bool usePeek) {
 			} else {
 				break;
 			}
-			if (printerOn) {
+			if (printerOn || consoleMode) {
 				DBGSerial.write(next);
 			}
 		}


### PR DESCRIPTION
While using `set console 1` characters were dropped from output. This was caused by not doing `DBGSerial.write(next)` in `consoleMode`.