### PR TITLE
improved palette handling

### DIFF
--- a/video/agon_screen.h
+++ b/video/agon_screen.h
@@ -114,19 +114,15 @@ int8_t setLogicalPalette(uint8_t l, uint8_t p, uint8_t r, uint8_t g, uint8_t b) 
 	}
 
 	debug_log("vdu_palette: %d,%d,%d,%d,%d\n\r", l, p, r, g, b);
+	uint8_t index = (col.R >> 6) << 4 | (col.G >> 6) << 2 | (col.B >> 6);
+	// update palette entry
+	palette[l] = index;
 	if (getVGAColourDepth() < 64) {		// If it is a paletted video mode
+		// change underlying output video palette
 		setPaletteItem(l, col);
 		updateRGB2PaletteLUT();
-	} else {
-		// adjust our palette array for new colour
-		// palette is an index into the colourLookup table, and our index is in 00RRGGBB format
-		uint8_t index = (col.R >> 6) << 4 | (col.G >> 6) << 2 | (col.B >> 6);
-		auto lookedup = colourLookup[index];
-		debug_log("vdu_palette: col.R %02X, col.G %02X, col.B %02X, index %d (%02X), lookup %02X, %02X, %02X\n\r", col.R, col.G, col.B, index, index, lookedup.R, lookedup.G, lookedup.B);
-		palette[l] = index;
-		return index;
 	}
-	return -1;
+	return index;
 }
 
 // Reset the palette and set the foreground and background drawing colours

--- a/video/context/graphics.h
+++ b/video/context/graphics.h
@@ -548,8 +548,8 @@ void Context::setGraphicsColour(uint8_t mode, uint8_t colour) {
 // Update selected colours based on palette change in 64 colour modes
 //
 void Context::updateColours(uint8_t l, uint8_t index) {
+	plottingText = false;
 	auto lookedup = colourLookup[index];
-	palette[l] = index;
 	if (l == tfgc) {
 		tfg = lookedup;
 	}

--- a/video/vdu.h
+++ b/video/vdu.h
@@ -255,7 +255,6 @@ void VDUStreamProcessor::vdu_palette() {
 	auto index = setLogicalPalette(l, p, r, g, b);
 
 	if (index != -1) {
-		// palette item in a 64 colour mode changed, so we may need to update our active colours
 		// TODO iterate over all stored contexts and update the palette
 		context->updateColours(l, index);
 	}


### PR DESCRIPTION
addresses an issue caused the the inclusion of new `updateRGB2PaletteLUT()` call when changing palette entries on paletted modes

the underlying issue was caused by the fact that the VDP was _not_ maintaining its own palette on these screen modes, and instead relying on the underlying LUT being essentially incorrect.  the LUT not being updated meant that an attempt to translate an incorrect RGB888 colour (as requested by the agon-vdp code) would translate to the _new_ signal colour (in the vdp-gl code)

this revision updates the agon-vdp side palette for all screen modes, thus meaning the updated LUT will operate correctly

this does introduce a new oddity related to duplicate palette entries, which the VDP previously didn’t appear to suffer from.  selecting “colour 14” when it has been redefined to be a duplicate of “colour 1” will end up resulting in pixels of “colour 1” now being drawn into the framebuffer.  this is “correct”/expected behaviour for fab-gl, but might be unexpected for Agon users.  it is however an edge-case that most users should not encounter, and is best addressed at this time through documentation