### PR TITLE
reset clipping rect on viewport reset

### DIFF
--- a/video/context/viewport.h
+++ b/video/context/viewport.h
@@ -51,6 +51,7 @@ void Context::viewportReset() {
 	graphicsViewport = Rect(0, 0, canvasW - 1, canvasH - 1);
 	activeViewport = &textViewport;
 	plottingText = false;
+	setClippingRect(textViewport);
 }
 
 void Context::setActiveViewport(ViewportType type) {


### PR DESCRIPTION
fixes an issue whereby cursor could be invisible after a viewport reset

fixes #254 