### PR TITLE
add “echo” feature to support redirection

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -95,6 +95,8 @@
 #define PACKET_RTC				0x07	// RTC
 #define PACKET_KEYSTATE			0x08	// Keyboard repeat rate and LED status
 #define PACKET_MOUSE			0x09	// Mouse data
+#define PACKET_ECHO				0x0A	// Echo
+#define PACKET_ECHO_END			0x0B	// Echo end
 
 #define AUDIO_CHANNELS			3		// Default number of audio channels
 #define AUDIO_DEFAULT_SAMPLE_RATE	16384	// Default sample rate
@@ -394,6 +396,9 @@
 #define TESTFLAG_AFFINE_TRANSFORM	1	// Affine transform test flag
 
 #define FEATUREFLAG_FULL_DUPLEX	0x0101	// Full duplex UART comms flag
+#define FEATUREFLAG_MOS_VDPP_BUFFERSIZE	0x0201	// Buffer size on MOS for VDP protocol packets
+#define FEATUREFLAG_ECHO		0x0210	// Echo back received data, for redirect/spool
+// #define FEATUREFLAG_ECHO_SETTINGS	0x0211	// Settings for what will be echo'd
 
 #define LOGICAL_SCRW			1280	// As per the BBC Micro standard
 #define LOGICAL_SCRH			1024

--- a/video/feature_flags.h
+++ b/video/feature_flags.h
@@ -12,8 +12,6 @@ std::unordered_map<uint16_t, uint16_t> featureFlags;	// Feature/Test flags
 extern VDUStreamProcessor *processor;
 
 void setFeatureFlag(uint16_t flag, uint16_t value) {
-	featureFlags[flag] = value;
-
 	switch (flag) {
 		case FEATUREFLAG_FULL_DUPLEX:
 			setVDPProtocolDuplex(value != 0);
@@ -23,14 +21,16 @@ void setFeatureFlag(uint16_t flag, uint16_t value) {
 			debug_log("Echo mode requested\n\r");
 			processor->setEcho(value != 0);
 			break;
+		case FEATUREFLAG_MOS_VDPP_BUFFERSIZE:
+			debug_log("Echo buffer size requested: %d\n\r", value);
+			break;
 	}
+
+	featureFlags[flag] = value;
 }
 
 void clearFeatureFlag(uint16_t flag) {
 	auto flagIter = featureFlags.find(flag);
-	if (flagIter != featureFlags.end()) {
-		featureFlags.erase(flagIter);
-	}
 
 	switch (flag) {
 		case FEATUREFLAG_FULL_DUPLEX:
@@ -42,6 +42,10 @@ void clearFeatureFlag(uint16_t flag) {
 			processor->setEcho(false);
 			break;
 	}
+
+	if (flagIter != featureFlags.end()) {
+		featureFlags.erase(flagIter);
+	}
 }
 
 inline bool isFeatureFlagSet(uint16_t flag) {
@@ -52,7 +56,8 @@ inline bool isFeatureFlagSet(uint16_t flag) {
 inline uint16_t getFeatureFlag(uint16_t flag) {
 	auto flagIter = featureFlags.find(flag);
 	if (flagIter != featureFlags.end()) {
-		return flagIter->second;
+		return featureFlags[flag];
+		// return flagIter->second;
 	}
 	return 0;
 }

--- a/video/feature_flags.h
+++ b/video/feature_flags.h
@@ -5,9 +5,11 @@
 #include <unordered_map>
 
 #include "agon.h"
+#include "vdu_stream_processor.h"
 #include "vdp_protocol.h"
 
 std::unordered_map<uint16_t, uint16_t> featureFlags;	// Feature/Test flags
+extern VDUStreamProcessor *processor;
 
 void setFeatureFlag(uint16_t flag, uint16_t value) {
 	featureFlags[flag] = value;
@@ -17,10 +19,14 @@ void setFeatureFlag(uint16_t flag, uint16_t value) {
 			setVDPProtocolDuplex(value != 0);
 			debug_log("Full duplex mode requested\n\r");
 			break;
+		case FEATUREFLAG_ECHO:
+			debug_log("Echo mode requested\n\r");
+			processor->setEcho(value != 0);
+			break;
 	}
 }
 
-inline void clearFeatureFlag(uint16_t flag) {
+void clearFeatureFlag(uint16_t flag) {
 	auto flagIter = featureFlags.find(flag);
 	if (flagIter != featureFlags.end()) {
 		featureFlags.erase(flagIter);
@@ -30,6 +36,10 @@ inline void clearFeatureFlag(uint16_t flag) {
 		case FEATUREFLAG_FULL_DUPLEX:
 			setVDPProtocolDuplex(false);
 			debug_log("Full duplex mode disabled\n\r");
+			break;
+		case FEATUREFLAG_ECHO:
+			debug_log("Echo mode disabled\n\r");
+			processor->setEcho(false);
 			break;
 	}
 }

--- a/video/vdu.h
+++ b/video/vdu.h
@@ -201,7 +201,7 @@ void VDUStreamProcessor::vdu_print(char c, bool usePeek) {
 			}
 			auto next = inputStream->peek();
 			if (next == 27) {
-				inputStream->read();
+				readByte();		// discard byte we have peeked
 				if (consoleMode) {
 					DBGSerial.write(next);
 				}
@@ -212,7 +212,7 @@ void VDUStreamProcessor::vdu_print(char c, bool usePeek) {
 				s += (char)next;
 			} else if ((next >= 0x20 && next <= 0x7E) || (next >= 0x80 && next <= 0xFF)) {
 				s += (char)next;
-				inputStream->read();
+				readByte();		// discard byte we have peeked
 			} else {
 				break;
 			}

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -21,6 +21,8 @@ std::unordered_map<uint16_t, ContextVectorPtr,
 	std::hash<uint16_t>, std::equal_to<uint16_t>,
 	psram_allocator<std::pair<const uint16_t, ContextVectorPtr>>> contextStacks;
 
+extern uint16_t getFeatureFlag(uint16_t flag);
+
 class VDUStreamProcessor {
 	private:
 		std::shared_ptr<Stream> inputStream;
@@ -32,6 +34,10 @@ class VDUStreamProcessor {
 		ContextVectorPtr contextStack;			// Current active context stack
 
 		bool commandsEnabled = true;
+		bool echoEnabled = false;
+		bool echoBuffering = false;
+
+		std::vector<uint8_t> echoBuffer;
 
 		int16_t readByte_t(uint16_t timeout);
 		int32_t readWord_t(uint16_t timeout);
@@ -42,6 +48,11 @@ class VDUStreamProcessor {
 		int16_t peekByte_t(uint16_t timeout);
 		float readFloat_t(bool is16Bit, bool isFixed, int8_t shift, uint16_t timeout);
 		bool readFloatArguments(float *values, int count, bool useBufferValue, bool useAdvancedOffsets, bool useMultiFormat);
+
+		inline void pushEcho(uint8_t c);
+		void pushEcho(uint8_t * chars, uint32_t length);
+		inline void clearEcho();
+		void flushEcho();
 
 		void vdu_print(char c, bool usePeek);
 		void vdu_colour();
@@ -161,7 +172,9 @@ class VDUStreamProcessor {
 			return inputStream->available() > 0;
 		}
 		inline uint8_t readByte() {
-			return inputStream->read();
+			auto read = inputStream->read();
+			pushEcho(read);
+			return read;
 		}
 		inline void writeByte(uint8_t b) {
 			if (outputStream) {
@@ -189,6 +202,15 @@ class VDUStreamProcessor {
 		void wait_eZ80();
 		void sendModeInformation();
 
+		void setEcho(bool enabled) {
+			flushEcho();
+			echoEnabled = enabled;
+			if (!enabled) {
+				// Send an echo end packet
+				send_packet(PACKET_ECHO_END, 0, nullptr);
+			}
+		}
+
 		std::shared_ptr<Context> getContext() {
 			return context;
 		}
@@ -204,6 +226,7 @@ class VDUStreamProcessor {
 int16_t inline VDUStreamProcessor::readByte_t(uint16_t timeout = COMMS_TIMEOUT) {
 	auto read = inputStream->read();
 	if (read != -1) {
+		pushEcho(read);
 		return read;
 	}
 
@@ -212,11 +235,8 @@ int16_t inline VDUStreamProcessor::readByte_t(uint16_t timeout = COMMS_TIMEOUT) 
 
 	do {
 		read = inputStream->read();
-		if (read != -1) {
-			return read;
-		}
-	} while (xTaskGetTickCountFromISR() - start < timeCheck);
-
+	} while (read == -1 && (xTaskGetTickCountFromISR() - start < timeCheck));
+	pushEcho(read);
 	return read;
 }
 
@@ -282,6 +302,7 @@ uint32_t VDUStreamProcessor::readIntoBuffer(uint8_t * buffer, uint32_t length, u
 				return remaining;
 			}
 		}
+		pushEcho(buffer, read);
 		buffer += read;
 		remaining -= read;
 	}
@@ -428,6 +449,7 @@ void VDUStreamProcessor::sendMouseData(MouseDelta * delta = nullptr) {
 //
 void VDUStreamProcessor::processAllAvailable() {
 	while (byteAvailable()) {
+		flushEcho();
 		vdu(readByte());
 	}
 }
@@ -436,8 +458,61 @@ void VDUStreamProcessor::processAllAvailable() {
 //
 void VDUStreamProcessor::processNext() {
 	if (byteAvailable()) {
+		flushEcho();
 		vdu(readByte());
 	}
+}
+
+inline void VDUStreamProcessor::pushEcho(uint8_t c) {
+	if (echoBuffering) {
+		echoBuffer.push_back(c);
+	}
+}
+
+void VDUStreamProcessor::pushEcho(uint8_t * chars, uint32_t length) {
+	if (echoBuffering) {
+		for (uint32_t i = 0; i < length; i++) {
+			echoBuffer.push_back(chars[i]);
+		}
+	}
+}
+
+inline void VDUStreamProcessor::clearEcho() {
+	echoBuffering = false;
+	echoBuffer.clear();
+}
+
+void VDUStreamProcessor::flushEcho() {
+	echoBuffering = echoEnabled;
+
+	if (!echoEnabled || echoBuffer.empty()) {
+		return;
+	}
+
+	uint32_t bufferSize = getFeatureFlag(FEATUREFLAG_MOS_VDPP_BUFFERSIZE) || 16;
+
+	// Iterate over the echoBuffer, sending packets of max bufferSize bytes
+	uint32_t remaining = echoBuffer.size();
+	uint32_t offset = 0;
+	while (remaining > 0) {
+		uint32_t packetSize = remaining > bufferSize ? bufferSize : remaining;
+		uint8_t packet[bufferSize];
+		for (uint32_t i = 0; i < packetSize; i++) {
+			packet[i] = echoBuffer[offset + i];
+		}
+		send_packet(PACKET_ECHO, packetSize, packet);
+		offset += packetSize;
+		remaining -= packetSize;
+	}
+
+	// send echo buffer as hex to debug log
+	debug_log("Echo: ");
+	for (auto c : echoBuffer) {
+		debug_log("%02X ", c);
+	}
+	debug_log("\n\r");
+	
+	echoBuffer.clear();
 }
 
 #include "vdu.h"

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -107,9 +107,11 @@ void VDUStreamProcessor::vdu_sys() {
 				}
 			}	break;
 			case 0x1B: {					// VDU 23, 27
+				clearEcho();				// Don't echo bitmap/sprite commands
 				vdu_sys_sprites();			// Sprite system control
 			}	break;
 			case 0x1C: {					// VDU 23, 28
+				clearEcho();				// Don't echo hexload commands
 				vdu_sys_hexload();
 			}	break;
 		}
@@ -130,6 +132,9 @@ void VDUStreamProcessor::vdu_sys() {
 //
 void VDUStreamProcessor::vdu_sys_video() {
 	auto mode = readByte_t();
+
+	// TODO - consider whether we want to clear echo for _all_ VDU 23 commands
+	clearEcho();
 
 	switch (mode) {
 		case VDP_CURSOR_VSTART: {		// VDU 23, 0, &0A, offset


### PR DESCRIPTION
add an “echo” flag system

commands received whilst the echo flag is active will be echo’d back to MOS.  this is currently done on a command-by-command basis.  an echo is sent when the _next_ command is processed, flushing the buffer

some commands automatically clear the echo buffer ensuring that they do not get echo’d