### PR TITLE
fix wait for vsync command

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@ board_build.f_cpu = 240000000L
 board_build.f_flash = 80000000L
 framework = arduino
 lib_deps =
-    https://github.com/AgonConsole8/vdp-gl.git#get-bitmap-pixel
+    https://github.com/AgonConsole8/vdp-gl.git#canvas-noop
     fbiego/ESP32Time@^2.0.0
     robtillaart/CRC@^1.0.3
 build_unflags = -Os

--- a/video/agon_screen.h
+++ b/video/agon_screen.h
@@ -417,6 +417,7 @@ void switchBuffer() {
 	if (isDoubleBuffered()) {
 		canvas->swapBuffers();
 	} else {
+		canvas->noOp();
 		waitPlotCompletion(true);
 	}
 }


### PR DESCRIPTION
ensures that `canvas->noOp()` is called before `canvas->waitCompletion(true)` when the “wait for vsync” command is processed.  when the drawing queue is empty `waitCompletion` always returns immediately, so this ensures that a no-op is present in the queue waiting to be processed.

fixes #271 