### PR TITLE
add feature flag 0x300 for tile engine

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -74,12 +74,13 @@
 #define VDP_UPDATER				0xA1	// Update VDP
 #define VDP_LOGICALCOORDS		0xC0	// Switch BBC Micro style logical coords on and off
 #define VDP_LEGACYMODES			0xC1	// Switch VDP 1.03 compatible modes on and off
+#define VDP_LAYERS				0xC2	// Tile engine layer management commands (experimental)
 #define VDP_SWITCHBUFFER		0xC3	// Double buffering control
 #define VDP_CONTEXT				0xC8	// Context management commands
 #define VDP_FLUSH_DRAWING_QUEUE	0xCA	// Flush the drawing queue
 #define VDP_PATTERN_LENGTH		0xF2	// Set pattern length (*FX 163,242,n)
 #define VDP_FEATUREFLAG_SET		0xF8	// Set a test flag
-#define VDP_FEATUREFLAG_CLEAR		0xF9	// Clear a test flag
+#define VDP_FEATUREFLAG_CLEAR	0xF9	// Clear a test flag
 #define VDP_CONSOLEMODE			0xFE	// Switch console mode on and off
 #define VDP_TERMINALMODE		0xFF	// Switch to terminal mode
 
@@ -395,6 +396,7 @@
 #define TESTFLAG_AFFINE_TRANSFORM	1	// Affine transform test flag
 
 #define FEATUREFLAG_FULL_DUPLEX	0x0101	// Full duplex UART comms flag
+#define FEATUREFLAG_TILE_ENGINE	0x0300	// Tile engine flag (layers commands)
 
 #define LOGICAL_SCRW			1280	// As per the BBC Micro standard
 #define LOGICAL_SCRH			1024

--- a/video/vdu_layers.h
+++ b/video/vdu_layers.h
@@ -10,7 +10,8 @@
 // #include "vdu_layers.h"
 // in vdu_sys.h and is called by VDUStreamProcessor::vdu_sys_video()
 
-#define VDP_LAYERS							0xC2		// VDU 23,0,194
+#include "vdu_stream_processor.h"
+
 #define VDP_LAYER_TILEBANK_INIT				0x00		// VDU 23,0,194,0
 #define VDP_LAYER_TILEBANK_LOAD				0x01		// VDU 23,0,194,1
 #define VDP_LAYER_TILEBANK_LOAD_BUFFER		0x02		// VDU 23,0,194,2	[Future]

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -318,6 +318,9 @@ void VDUStreamProcessor::vdu_sys_video() {
 			}
 		}	break;
 		case VDP_LAYERS: {				// VDU 23, 0, &C2, n
+			if (!isFeatureFlagSet(FEATUREFLAG_TILE_ENGINE)) {
+				return;
+			}
 			vdu_sys_layers();
 		}	break;
 		case VDP_SWITCHBUFFER: {		// VDU 23, 0, &C3


### PR DESCRIPTION
`VDU 23,0,&C2,n` now checks whether the “tile engine” feature flag has been set before processing the command

this will allow us to release the tile engine whilst the API is still in a state of potential flux