### PR TITLE
Add preliminary “copper” functions

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@ board_build.f_cpu = 240000000L
 board_build.f_flash = 80000000L
 framework = arduino
 lib_deps =
-    https://github.com/AgonConsole8/vdp-gl.git#copper-effects
+    https://github.com/AgonConsole8/vdp-gl.git#hard-copper
     fbiego/ESP32Time@^2.0.0
     robtillaart/CRC@^1.0.3
 build_unflags = -Os

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,14 +12,14 @@
 src_dir = video
 
 [env:esp32dev]
-platform = espressif32@6.6.0 ;v6.4.0 breaks video mode 3 because it uses more memory
+platform = espressif32@6.6.0 ;v6.9.0 uses about 0.5kb more internal RAM
 board = esp32dev
 board_build.flash_mode = qio
 board_build.f_cpu = 240000000L
 board_build.f_flash = 80000000L
 framework = arduino
 lib_deps =
-    https://github.com/AgonConsole8/vdp-gl.git#canvas-noop
+    https://github.com/AgonConsole8/vdp-gl.git#copper-effects
     fbiego/ESP32Time@^2.0.0
     robtillaart/CRC@^1.0.3
 build_unflags = -Os

--- a/video/agon.h
+++ b/video/agon.h
@@ -76,6 +76,7 @@
 #define VDP_LEGACYMODES			0xC1	// Switch VDP 1.03 compatible modes on and off
 #define VDP_LAYERS				0xC2	// Tile engine layer management commands (experimental)
 #define VDP_SWITCHBUFFER		0xC3	// Double buffering control
+#define VDP_COPPER				0xC4	// "Copper" style commands
 #define VDP_CONTEXT				0xC8	// Context management commands
 #define VDP_FLUSH_DRAWING_QUEUE	0xCA	// Flush the drawing queue
 #define VDP_PATTERN_LENGTH		0xF2	// Set pattern length (*FX 163,242,n)
@@ -392,11 +393,19 @@
 #define BUFFERED_BITMAP_BASEID	0xFA00	// Base ID for buffered bitmaps
 #define BUFFERED_SAMPLE_BASEID	0xFB00	// Base ID for buffered samples
 
+// Copper commands
+#define COPPER_CREATE_PALETTE		0		// Create a palette
+#define COPPER_DELETE_PALLETE		1		// Delete a palette
+#define COPPER_SET_PALETTE_COLOUR	2		// Set a palette item (colour)
+#define COPPER_UPDATE_SIGNALLIST	3		// Update the signal list
+#define COPPER_RESET_SIGNALLIST		4		// Reset the signal list
+
 // Test/Feature flags
 #define TESTFLAG_AFFINE_TRANSFORM	1	// Affine transform test flag
 
 #define FEATUREFLAG_FULL_DUPLEX	0x0101	// Full duplex UART comms flag
 #define FEATUREFLAG_TILE_ENGINE	0x0300	// Tile engine flag (layers commands)
+#define FEATUREFLAG_COPPER		0x0310	// Copper feature flag
 
 #define LOGICAL_SCRW			1280	// As per the BBC Micro standard
 #define LOGICAL_SCRH			1024

--- a/video/agon.h
+++ b/video/agon.h
@@ -274,8 +274,8 @@
 #define BUFFERED_COMPRESS				0x40	// Compress blocks from multiple buffers into one buffer
 #define BUFFERED_DECOMPRESS				0x41	// Decompress blocks from multiple buffers into one buffer
 #define BUFFERED_EXPAND_BITMAP			0x48	// Expand a bitmap buffer
-#define BUFFERED_ADD_VSYNC_CALLBACK		0x50	// Add a VSync callback
-#define BUFFERED_REMOVE_VSYNC_CALLBACK	0x51	// Remove a VSync callback
+#define BUFFERED_ADD_CALLBACK			0x50	// Add a callback
+#define BUFFERED_REMOVE_CALLBACK		0x51	// Remove a callback
 // #define BUFFERED_ADD_TIMER_CALLBACK		0x52	// Add a timer callback
 // #define BUFFERED_REMOVE_TIMER_CALLBACK	0x53	// Remove a timer callback
 
@@ -403,6 +403,11 @@
 #define COPPER_SET_PALETTE_COLOUR	2		// Set a palette item (colour)
 #define COPPER_UPDATE_SIGNALLIST	3		// Update the signal list
 #define COPPER_RESET_SIGNALLIST		4		// Reset the signal list
+
+// Callback types
+#define CALLBACK_VSYNC				0		// VSync callback
+#define CALLBACK_MODE_CHANGE		1		// Mode callback
+// Future callback types may include timer, audio playback complete, etc.
 
 // Test/Feature flags
 #define TESTFLAG_AFFINE_TRANSFORM	1	// Affine transform test flag

--- a/video/agon.h
+++ b/video/agon.h
@@ -274,6 +274,10 @@
 #define BUFFERED_COMPRESS				0x40	// Compress blocks from multiple buffers into one buffer
 #define BUFFERED_DECOMPRESS				0x41	// Decompress blocks from multiple buffers into one buffer
 #define BUFFERED_EXPAND_BITMAP			0x48	// Expand a bitmap buffer
+#define BUFFERED_ADD_VSYNC_CALLBACK		0x50	// Add a VSync callback
+#define BUFFERED_REMOVE_VSYNC_CALLBACK	0x51	// Remove a VSync callback
+// #define BUFFERED_ADD_TIMER_CALLBACK		0x52	// Add a timer callback
+// #define BUFFERED_REMOVE_TIMER_CALLBACK	0x53	// Remove a timer callback
 
 #define BUFFERED_DEBUG_INFO				0x80	// Get debug info about a buffer
 

--- a/video/agon_screen.h
+++ b/video/agon_screen.h
@@ -58,6 +58,54 @@ void updateRGB2PaletteLUT() {
 	}
 }
 
+// Create a palette
+//
+void createPalette(uint16_t paletteId) {
+	// Use instance, as call not present on VGABaseController, only on VGAPaletteController derived classes
+	switch (_VGAColourDepth) {
+		case 2: fabgl::VGA2Controller::instance()->createPalette(paletteId); break;
+		case 4: fabgl::VGA4Controller::instance()->createPalette(paletteId); break;
+		case 8: fabgl::VGA8Controller::instance()->createPalette(paletteId); break;
+		case 16: fabgl::VGA16Controller::instance()->createPalette(paletteId); break;
+	}
+}
+
+// Delete a palette
+//
+void deletePalette(uint16_t paletteId) {
+	// Use instance, as call not present on VGABaseController, only on VGAPaletteController derived classes
+	switch (_VGAColourDepth) {
+		case 2: fabgl::VGA2Controller::instance()->deletePalette(paletteId); break;
+		case 4: fabgl::VGA4Controller::instance()->deletePalette(paletteId); break;
+		case 8: fabgl::VGA8Controller::instance()->deletePalette(paletteId); break;
+		case 16: fabgl::VGA16Controller::instance()->deletePalette(paletteId); break;
+	}
+}
+
+// Set item in palette
+//
+void setItemInPalette(uint16_t paletteId, uint8_t index, RGB888 colour) {
+	// Use instance, as call not present on VGABaseController, only on VGAPaletteController derived classes
+	switch (_VGAColourDepth) {
+		case 2: fabgl::VGA2Controller::instance()->setItemInPalette(paletteId, index, colour); break;
+		case 4: fabgl::VGA4Controller::instance()->setItemInPalette(paletteId, index, colour); break;
+		case 8: fabgl::VGA8Controller::instance()->setItemInPalette(paletteId, index, colour); break;
+		case 16: fabgl::VGA16Controller::instance()->setItemInPalette(paletteId, index, colour); break;
+	}
+}
+
+// Update signal list
+//
+void updateSignalList(uint16_t * signalList, uint16_t count) {
+	// Use instance, as call not present on VGABaseController, only on VGA16Controller
+	switch (_VGAColourDepth) {
+		case 2: fabgl::VGA2Controller::instance()->updateSignalList(signalList, count); break;
+		case 4: fabgl::VGA4Controller::instance()->updateSignalList(signalList, count); break;
+		case 8: fabgl::VGA8Controller::instance()->updateSignalList(signalList, count); break;
+		case 16: fabgl::VGA16Controller::instance()->updateSignalList(signalList, count); break;
+	}
+}
+
 // Get current colour depth
 //
 inline uint8_t getVGAColourDepth() {

--- a/video/agon_screen.h
+++ b/video/agon_screen.h
@@ -49,60 +49,45 @@ std::unique_ptr<fabgl::VGABaseController> getVGAController(uint8_t colours) {
 // Update the internal FabGL LUT
 //
 void updateRGB2PaletteLUT() {
-	// Use instance, as call not present on VGABaseController
-	switch (_VGAColourDepth) {
-		case 2: fabgl::VGA2Controller::instance()->updateRGB2PaletteLUT(); break;
-		case 4: fabgl::VGA4Controller::instance()->updateRGB2PaletteLUT(); break;
-		case 8: fabgl::VGA8Controller::instance()->updateRGB2PaletteLUT(); break;
-		case 16: fabgl::VGA16Controller::instance()->updateRGB2PaletteLUT(); break;
+	if (_VGAColourDepth <= 16) {
+		fabgl::VGAPalettedController * controller = (fabgl::VGAPalettedController *)(_VGAController.get());
+		controller->updateRGB2PaletteLUT();
 	}
 }
 
 // Create a palette
 //
 void createPalette(uint16_t paletteId) {
-	// Use instance, as call not present on VGABaseController, only on VGAPaletteController derived classes
-	switch (_VGAColourDepth) {
-		case 2: fabgl::VGA2Controller::instance()->createPalette(paletteId); break;
-		case 4: fabgl::VGA4Controller::instance()->createPalette(paletteId); break;
-		case 8: fabgl::VGA8Controller::instance()->createPalette(paletteId); break;
-		case 16: fabgl::VGA16Controller::instance()->createPalette(paletteId); break;
+	if (_VGAColourDepth <= 16) {
+		fabgl::VGAPalettedController * controller = (fabgl::VGAPalettedController *)(_VGAController.get());
+		controller->createPalette(paletteId);
 	}
 }
 
 // Delete a palette
 //
 void deletePalette(uint16_t paletteId) {
-	// Use instance, as call not present on VGABaseController, only on VGAPaletteController derived classes
-	switch (_VGAColourDepth) {
-		case 2: fabgl::VGA2Controller::instance()->deletePalette(paletteId); break;
-		case 4: fabgl::VGA4Controller::instance()->deletePalette(paletteId); break;
-		case 8: fabgl::VGA8Controller::instance()->deletePalette(paletteId); break;
-		case 16: fabgl::VGA16Controller::instance()->deletePalette(paletteId); break;
+	if (_VGAColourDepth <= 16) {
+		fabgl::VGAPalettedController * controller = (fabgl::VGAPalettedController *)(_VGAController.get());
+		controller->deletePalette(paletteId);
 	}
 }
 
 // Set item in palette
 //
 void setItemInPalette(uint16_t paletteId, uint8_t index, RGB888 colour) {
-	// Use instance, as call not present on VGABaseController, only on VGAPaletteController derived classes
-	switch (_VGAColourDepth) {
-		case 2: fabgl::VGA2Controller::instance()->setItemInPalette(paletteId, index, colour); break;
-		case 4: fabgl::VGA4Controller::instance()->setItemInPalette(paletteId, index, colour); break;
-		case 8: fabgl::VGA8Controller::instance()->setItemInPalette(paletteId, index, colour); break;
-		case 16: fabgl::VGA16Controller::instance()->setItemInPalette(paletteId, index, colour); break;
+	if (_VGAColourDepth <= 16) {
+		fabgl::VGAPalettedController * controller = (fabgl::VGAPalettedController *)(_VGAController.get());
+		controller->setItemInPalette(paletteId, index, colour);
 	}
 }
 
 // Update signal list
 //
 void updateSignalList(uint16_t * signalList, uint16_t count) {
-	// Use instance, as call not present on VGABaseController, only on VGA16Controller
-	switch (_VGAColourDepth) {
-		case 2: fabgl::VGA2Controller::instance()->updateSignalList(signalList, count); break;
-		case 4: fabgl::VGA4Controller::instance()->updateSignalList(signalList, count); break;
-		case 8: fabgl::VGA8Controller::instance()->updateSignalList(signalList, count); break;
-		case 16: fabgl::VGA16Controller::instance()->updateSignalList(signalList, count); break;
+	if (_VGAColourDepth <= 16) {
+		fabgl::VGAPalettedController * controller = (fabgl::VGAPalettedController *)(_VGAController.get());
+		controller->updateSignalList(signalList, count);
 	}
 }
 
@@ -119,14 +104,9 @@ inline uint8_t getVGAColourDepth() {
 // 
 void setPaletteItem(uint8_t l, RGB888 c) {
 	auto depth = getVGAColourDepth();
-	if (l < depth) {
-		// Use instance, as call not present on VGABaseController
-		switch (depth) {
-			case 2: fabgl::VGA2Controller::instance()->setPaletteItem(l, c); break;
-			case 4: fabgl::VGA4Controller::instance()->setPaletteItem(l, c); break;
-			case 8: fabgl::VGA8Controller::instance()->setPaletteItem(l, c); break;
-			case 16: fabgl::VGA16Controller::instance()->setPaletteItem(l, c); break;
-		}
+	if (l < depth && depth <= 16) {
+		fabgl::VGAPalettedController * controller = (fabgl::VGAPalettedController *)(_VGAController.get());
+		controller->setPaletteItem(l, c);
 	}
 }
 

--- a/video/buffers.h
+++ b/video/buffers.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <vector>
 #include <unordered_map>
+#include <unordered_set>
 #include <mat.h>
 
 #include "agon.h"
@@ -13,6 +14,7 @@
 
 using BufferVector = std::vector<std::shared_ptr<BufferStream>, psram_allocator<std::shared_ptr<BufferStream>>>;
 std::unordered_map<uint16_t, BufferVector, std::hash<uint16_t>, std::equal_to<uint16_t>, psram_allocator<std::pair<const uint16_t, BufferVector>>> buffers;
+std::unordered_set<uint16_t> vsyncBuffers;
 
 struct AdvancedOffset {
 	uint32_t blockOffset = 0;

--- a/video/buffers.h
+++ b/video/buffers.h
@@ -14,7 +14,7 @@
 
 using BufferVector = std::vector<std::shared_ptr<BufferStream>, psram_allocator<std::shared_ptr<BufferStream>>>;
 std::unordered_map<uint16_t, BufferVector, std::hash<uint16_t>, std::equal_to<uint16_t>, psram_allocator<std::pair<const uint16_t, BufferVector>>> buffers;
-std::unordered_set<uint16_t> vsyncBuffers;
+std::unordered_map<uint16_t, std::unordered_set<uint16_t>> callbackBuffers;
 
 struct AdvancedOffset {
 	uint32_t blockOffset = 0;

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -135,13 +135,15 @@ class VDUStreamProcessor {
 		void bufferCompress(uint16_t bufferId, uint16_t sourceBufferId);
 		void bufferDecompress(uint16_t bufferId, uint16_t sourceBufferId);
 		void bufferExpandBitmap(uint16_t bufferId, uint8_t options, uint16_t sourceBufferId);
+		void bufferAddVSYNCCallback(uint16_t bufferId);
+		void bufferRemoveVSYNCCallback(uint16_t bufferId);
 
 		void vdu_sys_updater();
 		void unlock();
 		void receiveFirmware();
 		void switchFirmware();
 
-				// Begin: Tile Engine
+		// Begin: Tile Engine
 
 		void vdu_sys_layers();
 		void vdu_sys_layers_tilebank_init(uint8_t tileBankNum, uint8_t tileBankBitDepth);
@@ -276,6 +278,8 @@ class VDUStreamProcessor {
 		bool contextExists(uint8_t id) {
 			return contextStacks.find(id) != contextStacks.end();
 		}
+
+		void bufferCallVSYNCCallbacks();
 };
 
 // Read an unsigned byte from the serial port, with a timeout

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -69,6 +69,7 @@ class VDUStreamProcessor {
 		void sendKeyboardState();
 		void vdu_sys_keystate();
 		void vdu_sys_mouse();
+		void vdu_sys_copper();
 		void vdu_sys_scroll();
 		void vdu_sys_cursorBehaviour();
 		void vdu_sys_udg(char c);

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -47,7 +47,6 @@ class VDUStreamProcessor {
 		void vdu_colour();
 		void vdu_gcol();
 		void vdu_palette();
-		void vdu_mode();
 		void vdu_graphicsViewport();
 		void vdu_plot();
 		void vdu_resetViewports();
@@ -135,8 +134,8 @@ class VDUStreamProcessor {
 		void bufferCompress(uint16_t bufferId, uint16_t sourceBufferId);
 		void bufferDecompress(uint16_t bufferId, uint16_t sourceBufferId);
 		void bufferExpandBitmap(uint16_t bufferId, uint8_t options, uint16_t sourceBufferId);
-		void bufferAddVSYNCCallback(uint16_t bufferId);
-		void bufferRemoveVSYNCCallback(uint16_t bufferId);
+		void bufferAddCallback(uint16_t bufferId, uint16_t type);
+		void bufferRemoveCallback(uint16_t bufferId, uint16_t type);
 
 		void vdu_sys_updater();
 		void unlock();
@@ -279,7 +278,9 @@ class VDUStreamProcessor {
 			return contextStacks.find(id) != contextStacks.end();
 		}
 
-		void bufferCallVSYNCCallbacks();
+		void vdu_mode(uint8_t mode);
+
+		void bufferCallCallbacks(uint16_t type);
 };
 
 // Read an unsigned byte from the serial port, with a timeout

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -688,16 +688,12 @@ void VDUStreamProcessor::vdu_sys_copper() {
 		case COPPER_CREATE_PALETTE: {
 			auto paletteId = readWord_t(); if (paletteId == -1) return;
 
-			if (fabgl::VGA16Controller::instance()) {
-				fabgl::VGA16Controller::instance()->createPalette(paletteId);
-			}
+			createPalette(paletteId);
 		}	break;
 		case COPPER_DELETE_PALLETE: {
 			auto paletteId = readWord_t(); if (paletteId == -1) return;
 
-			if (fabgl::VGA16Controller::instance()) {
-				fabgl::VGA16Controller::instance()->deletePalette(paletteId);
-			}
+			deletePalette(paletteId);
 		}	break;
 		case COPPER_SET_PALETTE_COLOUR: {
 			auto paletteId = readWord_t(); if (paletteId == -1) return;
@@ -706,9 +702,7 @@ void VDUStreamProcessor::vdu_sys_copper() {
 			auto g = readByte_t(); if (g == -1) return;
 			auto b = readByte_t(); if (b == -1) return;
 
-			if (fabgl::VGA16Controller::instance()) {
-				fabgl::VGA16Controller::instance()->setItemInPalette(paletteId, index, RGB888(r, g, b));
-			}
+			setItemInPalette(paletteId, index, RGB888(r, g, b));
 		}	break;
 		case COPPER_UPDATE_SIGNALLIST: {
 			auto bufferId = readWord_t(); if (bufferId == -1) return;
@@ -721,15 +715,11 @@ void VDUStreamProcessor::vdu_sys_copper() {
 
 			// only use first block in buffer
 			auto buffer = bufferIter->second[0];
-			if (fabgl::VGA16Controller::instance()) {
-				fabgl::VGA16Controller::instance()->updateSignalList((uint16_t *)buffer->getBuffer(), buffer->size() / 4);
-			}
+			updateSignalList((uint16_t *)buffer->getBuffer(), buffer->size() / 4);
 		}	break;
 		case COPPER_RESET_SIGNALLIST: {
-			if (fabgl::VGA16Controller::instance()) {
-				uint16_t signalList[2] = { 0, 0 };
-				fabgl::VGA16Controller::instance()->updateSignalList(signalList, 1);
-			}
+			uint16_t signalList[2] = { 0, 0 };
+			updateSignalList(signalList, 1);
 		}	break;
 	}
 }

--- a/video/video.ino
+++ b/video/video.ino
@@ -75,6 +75,7 @@ TerminalState	terminalState = TerminalState::Disabled;		// Terminal state (for C
 bool			consoleMode = false;			// Serial console mode (0 = off, 1 = console enabled)
 bool			printerOn = false;				// Output "printer" to debug serial link
 bool			controlKeys = true;				// Control keys enabled
+uint			lastFrameCounter = 0;			// Last frame counter
 
 #include "version.h"							// Version information
 #include "agon_ps2.h"							// Keyboard support
@@ -149,8 +150,8 @@ void processLoop(void * parameter) {
 			continue;
 		}
 
-		if (_VGAController->frameCounter != 0) {
-			_VGAController->frameCounter = 0;
+		if (_VGAController->frameCounter != lastFrameCounter) {
+			lastFrameCounter = _VGAController->frameCounter;
 			processor->bufferCallCallbacks(CALLBACK_VSYNC);
 		}
 

--- a/video/video.ino
+++ b/video/video.ino
@@ -148,6 +148,12 @@ void processLoop(void * parameter) {
 		if (processTerminal()) {
 			continue;
 		}
+
+		if (_VGAController->frameCounter != 0) {
+			_VGAController->frameCounter = 0;
+			processor->bufferCallVSYNCCallbacks();
+		}
+
 		processor->doCursorFlash();
 
 		do_keyboard();

--- a/video/video.ino
+++ b/video/video.ino
@@ -151,7 +151,7 @@ void processLoop(void * parameter) {
 
 		if (_VGAController->frameCounter != 0) {
 			_VGAController->frameCounter = 0;
-			processor->bufferCallVSYNCCallbacks();
+			processor->bufferCallCallbacks(CALLBACK_VSYNC);
 		}
 
 		processor->doCursorFlash();
@@ -383,13 +383,7 @@ bool processTerminal() {
 			Terminal = nullptr;
 			auto context = processor->getContext();
 			// reset our screen mode
-			if (changeMode(videoMode) != 0) {
-				debug_log("processTerminal: Error %d changing back to mode %d\n\r", videoMode);
-				videoMode = 1;
-				changeMode(1);
-			}
-			context->reset();
-			processor->sendModeInformation();
+			processor->vdu_mode(videoMode);
 			debug_log("Terminal disabled\n\r");
 			terminalState = TerminalState::Disabled;
 		} break;


### PR DESCRIPTION
This PR adds "copper" style features to the VDP.  What this means is the ability to dynamically change the palette in palette-based screen modes during scan-out.  This enables the ability for screen modes with 2, 4 or 16 colours to potentially display all 64 colours on screen at once.

This adds a “copper” feature flag (`&310`), and VDU commands to use this new feature

VDU commands begin with `VDU 23,0,&C4,<command>`

The command set allows a palette, with a 16-bit ID, to be added, deleted, and for colours within that palette to be defined using RGB888 values (similar to normal palette changes).  Also the output “signal list” can be updated, which allows different palettes to be used on different rows during scan-out.  The command to update the signal list accepts a buffer which must contain pairs of 16-bit values to indicate the count of rows, and the palette ID to use for those rows.  If the signal list refers to a palette that has not been defined then the default palette (palette ID 0) will be used.

Closes #259 and #269
