### PR TITLE
Allow use of feature flags in buffered commands

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -272,6 +272,7 @@
 #define BUFFERED_MATRIX					0x22	// Create or combine a matrix buffer of arbitrary dimensions
 #define BUFFERED_TRANSFORM_BITMAP		0x28	// Create a new bitmap from an existing one by applying a 2d transform
 #define BUFFERED_TRANSFORM_DATA			0x29	// Transform data using a given matrix
+#define BUFFERED_READ_FLAG				0x30	// Read flag value into a buffer
 #define BUFFERED_COMPRESS				0x40	// Compress blocks from multiple buffers into one buffer
 #define BUFFERED_DECOMPRESS				0x41	// Decompress blocks from multiple buffers into one buffer
 #define BUFFERED_EXPAND_BITMAP			0x48	// Expand a bitmap buffer
@@ -310,7 +311,9 @@
 // Conditional operation flags
 #define COND_OP_MASK			0x0F	// conditional operation code mask
 #define COND_ADVANCED_OFFSETS	0x10	// advanced offset values
-#define COND_BUFFER_VALUE		0x20	// value to compare is a buffer-fetched value
+#define COND_BUFFER_VALUE		0x20	// value to compare against is a buffer-fetched value
+#define COND_FLAG_VALUE			0x40	// condition source value is a flag
+#define COND_16BIT				0x80	// values to compare are a 16-bit
 
 // Reverse operation flags
 #define REVERSE_16BIT			0x01	// 16-bit value length
@@ -389,6 +392,11 @@
 #define TRANSFORM_DATA_ADVANCED		0x10	// Advanced offsets
 #define TRANSFORM_DATA_BUFFER_ARGS	0x20	// Optional argument values are fetched from buffers
 #define TRANSFORM_DATA_PER_BLOCK	0x40	// Transform data per block
+
+// Read flag flags
+#define READ_FLAG_ADVANCED_OFFSETS	0x10	// advanced, 24-bit offsets (16-bit block offset follows if top bit set)
+#define READ_FLAG_USE_DEFAULT		0x40	// use default value if flag not set
+#define READ_FLAG_16BIT				0x80	// value to set is 16-bit
 
 // Buffered bitmap and sample info
 #define BUFFERED_BITMAP_BASEID	0xFA00	// Base ID for buffered bitmaps

--- a/video/agon.h
+++ b/video/agon.h
@@ -97,6 +97,8 @@
 #define PACKET_RTC				0x07	// RTC
 #define PACKET_KEYSTATE			0x08	// Keyboard repeat rate and LED status
 #define PACKET_MOUSE			0x09	// Mouse data
+#define PACKET_ECHO				0x0A	// Echo
+#define PACKET_ECHO_END			0x0B	// Echo end
 
 #define AUDIO_CHANNELS			3		// Default number of audio channels
 #define AUDIO_DEFAULT_SAMPLE_RATE	16384	// Default sample rate
@@ -396,6 +398,9 @@
 #define TESTFLAG_AFFINE_TRANSFORM	1	// Affine transform test flag
 
 #define FEATUREFLAG_FULL_DUPLEX	0x0101	// Full duplex UART comms flag
+#define FEATUREFLAG_MOS_VDPP_BUFFERSIZE	0x0201	// Buffer size on MOS for VDP protocol packets
+#define FEATUREFLAG_ECHO		0x0210	// Echo back received data, for redirect/spool
+// #define FEATUREFLAG_ECHO_SETTINGS	0x0211	// Settings for what will be echo'd
 #define FEATUREFLAG_TILE_ENGINE	0x0300	// Tile engine flag (layers commands)
 
 #define LOGICAL_SCRW			1280	// As per the BBC Micro standard

--- a/video/feature_flags.h
+++ b/video/feature_flags.h
@@ -12,8 +12,6 @@ std::unordered_map<uint16_t, uint16_t> featureFlags;	// Feature/Test flags
 extern VDUStreamProcessor *processor;
 
 void setFeatureFlag(uint16_t flag, uint16_t value) {
-	featureFlags[flag] = value;
-
 	switch (flag) {
 		case FEATUREFLAG_FULL_DUPLEX:
 			setVDPProtocolDuplex(value != 0);
@@ -23,14 +21,16 @@ void setFeatureFlag(uint16_t flag, uint16_t value) {
 			debug_log("Echo mode requested\n\r");
 			processor->setEcho(value != 0);
 			break;
+		case FEATUREFLAG_MOS_VDPP_BUFFERSIZE:
+			debug_log("Echo buffer size requested: %d\n\r", value);
+			break;
 	}
+
+	featureFlags[flag] = value;
 }
 
 void clearFeatureFlag(uint16_t flag) {
 	auto flagIter = featureFlags.find(flag);
-	if (flagIter != featureFlags.end()) {
-		featureFlags.erase(flagIter);
-	}
 
 	switch (flag) {
 		case FEATUREFLAG_FULL_DUPLEX:
@@ -42,6 +42,10 @@ void clearFeatureFlag(uint16_t flag) {
 			processor->setEcho(false);
 			break;
 	}
+
+	if (flagIter != featureFlags.end()) {
+		featureFlags.erase(flagIter);
+	}
 }
 
 inline bool isFeatureFlagSet(uint16_t flag) {
@@ -52,7 +56,8 @@ inline bool isFeatureFlagSet(uint16_t flag) {
 inline uint16_t getFeatureFlag(uint16_t flag) {
 	auto flagIter = featureFlags.find(flag);
 	if (flagIter != featureFlags.end()) {
-		return flagIter->second;
+		return featureFlags[flag];
+		// return flagIter->second;
 	}
 	return 0;
 }

--- a/video/feature_flags.h
+++ b/video/feature_flags.h
@@ -5,9 +5,11 @@
 #include <unordered_map>
 
 #include "agon.h"
+#include "vdu_stream_processor.h"
 #include "vdp_protocol.h"
 
 std::unordered_map<uint16_t, uint16_t> featureFlags;	// Feature/Test flags
+extern VDUStreamProcessor *processor;
 
 void setFeatureFlag(uint16_t flag, uint16_t value) {
 	featureFlags[flag] = value;
@@ -17,10 +19,14 @@ void setFeatureFlag(uint16_t flag, uint16_t value) {
 			setVDPProtocolDuplex(value != 0);
 			debug_log("Full duplex mode requested\n\r");
 			break;
+		case FEATUREFLAG_ECHO:
+			debug_log("Echo mode requested\n\r");
+			processor->setEcho(value != 0);
+			break;
 	}
 }
 
-inline void clearFeatureFlag(uint16_t flag) {
+void clearFeatureFlag(uint16_t flag) {
 	auto flagIter = featureFlags.find(flag);
 	if (flagIter != featureFlags.end()) {
 		featureFlags.erase(flagIter);
@@ -30,6 +36,10 @@ inline void clearFeatureFlag(uint16_t flag) {
 		case FEATUREFLAG_FULL_DUPLEX:
 			setVDPProtocolDuplex(false);
 			debug_log("Full duplex mode disabled\n\r");
+			break;
+		case FEATUREFLAG_ECHO:
+			debug_log("Echo mode disabled\n\r");
+			processor->setEcho(false);
 			break;
 	}
 }

--- a/video/vdu.h
+++ b/video/vdu.h
@@ -201,7 +201,7 @@ void VDUStreamProcessor::vdu_print(char c, bool usePeek) {
 			}
 			auto next = inputStream->peek();
 			if (next == 27) {
-				inputStream->read();
+				readByte();		// discard byte we have peeked
 				if (consoleMode) {
 					DBGSerial.write(next);
 				}
@@ -212,7 +212,7 @@ void VDUStreamProcessor::vdu_print(char c, bool usePeek) {
 				s += (char)next;
 			} else if ((next >= 0x20 && next <= 0x7E) || (next >= 0x80 && next <= 0xFF)) {
 				s += (char)next;
-				inputStream->read();
+				readByte();		// discard byte we have peeked
 			} else {
 				break;
 			}

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -142,6 +142,7 @@ class VDUStreamProcessor {
 		void bufferMatrixManipulate(uint16_t bufferId, uint8_t command, MatrixSize size);
 		void bufferTransformBitmap(uint16_t bufferId, uint8_t options, uint16_t transformBufferId, uint16_t sourceBufferId);
 		void bufferTransformData(uint16_t bufferId, uint8_t options, uint8_t format, uint16_t transformBufferId, uint16_t sourceBufferId);
+		void bufferReadFlag(uint16_t bufferId);
 		void bufferCompress(uint16_t bufferId, uint16_t sourceBufferId);
 		void bufferDecompress(uint16_t bufferId, uint16_t sourceBufferId);
 		void bufferExpandBitmap(uint16_t bufferId, uint8_t options, uint16_t sourceBufferId);

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -287,7 +287,14 @@ class VDUStreamProcessor {
 			echoEnabled = enabled;
 			if (!enabled) {
 				// Send an echo end packet
-				send_packet(PACKET_ECHO_END, 0, nullptr);
+				auto handle = getFeatureFlag(FEATUREFLAG_ECHO);
+				if (handle == 0) {
+					return;
+				}
+				uint8_t packet[] = {
+					static_cast<uint8_t>(handle & 0xFF),
+				};
+				send_packet(PACKET_ECHO_END, sizeof packet, packet);
 			}
 		}
 
@@ -569,7 +576,11 @@ void VDUStreamProcessor::flushEcho() {
 		return;
 	}
 
-	uint32_t bufferSize = getFeatureFlag(FEATUREFLAG_MOS_VDPP_BUFFERSIZE) || 16;
+	uint32_t bufferSize = getFeatureFlag(FEATUREFLAG_MOS_VDPP_BUFFERSIZE);
+	if (bufferSize == 0) {
+		bufferSize = 16;
+	}
+	debug_log("Echo buffer size: %d\n\r", bufferSize);
 
 	// Iterate over the echoBuffer, sending packets of max bufferSize bytes
 	uint32_t remaining = echoBuffer.size();
@@ -581,16 +592,17 @@ void VDUStreamProcessor::flushEcho() {
 			packet[i] = echoBuffer[offset + i];
 		}
 		send_packet(PACKET_ECHO, packetSize, packet);
+		debug_log("Echo %.*s\n\r", packetSize, packet);
 		offset += packetSize;
 		remaining -= packetSize;
 	}
 
-	// send echo buffer as hex to debug log
-	debug_log("Echo: ");
-	for (auto c : echoBuffer) {
-		debug_log("%02X ", c);
-	}
-	debug_log("\n\r");
+	// // send echo buffer as hex to debug log
+	// debug_log("Echo: ");
+	// for (auto c : echoBuffer) {
+	// 	debug_log("%02X ", c);
+	// }
+	// debug_log("\n\r");
 	
 	echoBuffer.clear();
 }

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -108,9 +108,11 @@ void VDUStreamProcessor::vdu_sys() {
 				}
 			}	break;
 			case 0x1B: {					// VDU 23, 27
+				clearEcho();				// Don't echo bitmap/sprite commands
 				vdu_sys_sprites();			// Sprite system control
 			}	break;
 			case 0x1C: {					// VDU 23, 28
+				clearEcho();				// Don't echo hexload commands
 				vdu_sys_hexload();
 			}	break;
 		}
@@ -131,6 +133,9 @@ void VDUStreamProcessor::vdu_sys() {
 //
 void VDUStreamProcessor::vdu_sys_video() {
 	auto mode = readByte_t();
+
+	// TODO - consider whether we want to clear echo for _all_ VDU 23 commands
+	clearEcho();
 
 	switch (mode) {
 		case VDP_CURSOR_VSTART: {		// VDU 23, 0, &0A, offset


### PR DESCRIPTION
Enhances "conditional" buffered commands to allow conditions to use a feature flag as the source value being checked against.  This is done by setting the bit `0x40` on the condition operation, and providing a `featureFlagId` instead of the `checkBufferId`.  When this flag is set a `checkOffset` must not be sent - it is meaningless when reading a flag.

Conditional checks now also support checking against 16-bit values, whether the source value is from a buffer, or from a feature flag, via setting the bit `0x80` on the condition operation.

A new buffered command has been added to allow for the value of a feature flag to be read and copied into a buffer at a given offset.  The format of this command is:
`VDU 23, 0, &A0, <bufferId>; &30, <options>, <offset>; <flagId>; [default[;]]`

The options byte accepts 3 bits to define how the operation will be processed, which is consistent with other commands.  The bits are as follows:

| Bit | Meaning |
| -- | -- |
| 0x10 | Use advanced offsets |
| 0x40 | Use a default value when flag is not set |
| 0x80 | Value is 16-bit |

The `default` value will only be read if the `0x40` bit has been set in the options byte, and will be read as an 8-bit or 16-bit value depending on whether the `0x80` bit of the options byte was set

NB this was built on top of #267 as that had improvements to how flags are supported