### PR TITLE
Expose graphics context state as “VDU Variables”

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -443,6 +443,7 @@
 #define FEATUREFLAG_BUFFERS_USED	0x0212	// Number of buffers used
 #define FEATUREFLAG_KEYBOARD_LAYOUT	0x0220	// Keyboard layout
 #define FEATUREFLAG_KEYBOARD_CTRL_KEYS	0x0221	// Control keys on/off
+#define FEATUREFLAG_CONTEXT_ID	0x0230	// Current active context ID
 #define FEATUREFLAG_TILE_ENGINE	0x0300	// Tile engine flag (layers commands)
 #define FEATUREFLAG_COPPER		0x0310	// Copper feature flag
 #define FEATURE_FLAG_AUTO_HW_SPRITES	0x0400	// Auto hardware sprites flag

--- a/video/agon.h
+++ b/video/agon.h
@@ -424,9 +424,11 @@
 #define TESTFLAG_HW_SPRITES			2	// Hardware sprites test flag
 
 #define FEATUREFLAG_FULL_DUPLEX	0x0101	// Full duplex UART comms flag
-#define FEATUREFLAG_MOS_VDPP_BUFFERSIZE	0x0201	// Buffer size on MOS for VDP protocol packets
-#define FEATUREFLAG_ECHO		0x0210	// Echo back received data, for redirect/spool
-// #define FEATUREFLAG_ECHO_SETTINGS	0x0211	// Settings for what will be echo'd
+#define FEATUREFLAG_MOS_VDPP_BUFFERSIZE	0x0102	// Buffer size on MOS for VDP protocol packets
+#define FEATUREFLAG_ECHO		0x0110	// Echo back received data, for redirect/spool
+// #define FEATUREFLAG_ECHO_SETTINGS	0x0111	// Settings for what will be echo'd
+#define FEATUREFLAG_VDU_VARIABLES_START	0x0200	// VDU variables start at 0x0200
+#define FEATUREFLAG_VDU_VARIABLES_END	0x02FF	// VDU variables end
 #define FEATUREFLAG_TILE_ENGINE	0x0300	// Tile engine flag (layers commands)
 #define FEATUREFLAG_COPPER		0x0310	// Copper feature flag
 #define FEATURE_FLAG_AUTO_HW_SPRITES	0x0400	// Auto hardware sprites flag

--- a/video/agon.h
+++ b/video/agon.h
@@ -432,6 +432,9 @@
 #define FEATUREFLAG_TILE_ENGINE	0x0300	// Tile engine flag (layers commands)
 #define FEATUREFLAG_COPPER		0x0310	// Copper feature flag
 #define FEATURE_FLAG_AUTO_HW_SPRITES	0x0400	// Auto hardware sprites flag
+#define FEATUREFLAG_VDU_VARIABLES_START	0x1000	// VDU variables start at 0x1000
+#define FEATUREFLAG_VDU_VARIABLES_END	0x1FFF	// VDU variables end
+#define FEATUREFLAG_VDU_VARIABLES_MASK	0x0FFF	// VDU variables mask
 
 #define LOGICAL_SCRW			1280	// As per the BBC Micro standard
 #define LOGICAL_SCRH			1024

--- a/video/agon.h
+++ b/video/agon.h
@@ -427,8 +427,22 @@
 #define FEATUREFLAG_MOS_VDPP_BUFFERSIZE	0x0102	// Buffer size on MOS for VDP protocol packets
 #define FEATUREFLAG_ECHO		0x0110	// Echo back received data, for redirect/spool
 // #define FEATUREFLAG_ECHO_SETTINGS	0x0111	// Settings for what will be echo'd
-#define FEATUREFLAG_VDU_VARIABLES_START	0x0200	// VDU variables start at 0x0200
-#define FEATUREFLAG_VDU_VARIABLES_END	0x02FF	// VDU variables end
+#define FEATUREFLAG_SYSTEM_BEGIN	0x0200	// General system settings start at 0x0200
+#define FEATUREFLAG_SYSTEM_END	0x02FF	// General system settings end
+#define FEATUREFLAG_RTC_YEAR	0x0200	// RTC year is 4 digits
+#define FEATUREFLAG_RTC_MONTH	0x0201	// RTC month is 1-12
+#define FEATUREFLAG_RTC_DAY		0x0202	// RTC day is 1-31
+#define FEATUREFLAG_RTC_HOUR	0x0203	// RTC hour is 0-23
+#define FEATUREFLAG_RTC_MINUTE	0x0204	// RTC minute is 0-59
+#define FEATUREFLAG_RTC_SECOND	0x0205	// RTC second is 0-59
+#define FEATUREFLAG_RTC_MILLIS	0x0206	// RTC millisecond is 0-999
+#define FEATUREFLAG_RTC_WEEKDAY	0x0207	// RTC weekday is 0-6
+#define FEATUREFLAG_RTC_YEARDAY	0x0208	// RTC day of year is 0-366
+#define FEATUREFLAG_FREEPSRAM_LOW	0x0210	// Free PSRAM low bytes
+#define FEATUREFLAG_FREEPSRAM_HIGH	0x0211	// Free PSRAM high bytes
+#define FEATUREFLAG_BUFFERS_USED	0x0212	// Number of buffers used
+#define FEATUREFLAG_KEYBOARD_LAYOUT	0x0220	// Keyboard layout
+#define FEATUREFLAG_KEYBOARD_CTRL_KEYS	0x0221	// Control keys on/off
 #define FEATUREFLAG_TILE_ENGINE	0x0300	// Tile engine flag (layers commands)
 #define FEATUREFLAG_COPPER		0x0310	// Copper feature flag
 #define FEATURE_FLAG_AUTO_HW_SPRITES	0x0400	// Auto hardware sprites flag

--- a/video/agon.h
+++ b/video/agon.h
@@ -435,6 +435,8 @@
 #define FEATUREFLAG_VDU_VARIABLES_START	0x1000	// VDU variables start at 0x1000
 #define FEATUREFLAG_VDU_VARIABLES_END	0x1FFF	// VDU variables end
 #define FEATUREFLAG_VDU_VARIABLES_MASK	0x0FFF	// VDU variables mask
+#define FEATUREFLAG_VDU_VAR_PALETTE		0x1200	// Palette variables start (block of 64)
+#define FEATUREFLAG_VDU_VAR_PALETTE_END	0x123F	// Palette variables end
 
 #define LOGICAL_SCRW			1280	// As per the BBC Micro standard
 #define LOGICAL_SCRH			1024

--- a/video/agon.h
+++ b/video/agon.h
@@ -435,8 +435,11 @@
 #define FEATUREFLAG_VDU_VARIABLES_START	0x1000	// VDU variables start at 0x1000
 #define FEATUREFLAG_VDU_VARIABLES_END	0x1FFF	// VDU variables end
 #define FEATUREFLAG_VDU_VARIABLES_MASK	0x0FFF	// VDU variables mask
-#define FEATUREFLAG_VDU_VAR_PALETTE		0x1200	// Palette variables start (block of 64)
-#define FEATUREFLAG_VDU_VAR_PALETTE_END	0x123F	// Palette variables end
+
+#define VDU_VAR_PALETTE			0x200	// Palette variables start (block of 64)
+#define VDU_VAR_PALETTE_END		0x23F	// Palette variables end
+#define VDU_VAR_CHARMAPPING		0x300	// Character to bitmap mapping start (block of 256)
+#define VDU_VAR_CHARMAPPING_END	0x3FF	// Character to bitmap mapping end
 
 #define LOGICAL_SCRW			1280	// As per the BBC Micro standard
 #define LOGICAL_SCRH			1024

--- a/video/agon_ps2.h
+++ b/video/agon_ps2.h
@@ -13,6 +13,7 @@ uint8_t			_keycode = 0;					// Last pressed key code
 uint8_t			_modifiers = 0;					// Last pressed key modifiers
 uint16_t		kbRepeatDelay = 500;			// Keyboard repeat delay ms (250, 500, 750 or 1000)		
 uint16_t		kbRepeatRate = 100;				// Keyboard repeat rate ms (between 33 and 500)
+uint8_t			kbRegion = 0;					// Keyboard region
 
 bool			mouseEnabled = false;			// Mouse enabled
 uint8_t			mSampleRate = MOUSE_DEFAULT_SAMPLERATE;	// Mouse sample rate
@@ -84,8 +85,10 @@ void setKeyboardLayout(uint8_t region) {
 		case 17: kb->setLayout(&fabgl::DvorakLayout); break;
 		default:
 			kb->setLayout(&fabgl::UKLayout);
+			region = 0;
 			break;
 	}
+	kbRegion = region;
 }
 
 // Get keyboard key presses

--- a/video/agon_screen.h
+++ b/video/agon_screen.h
@@ -144,7 +144,7 @@ int8_t setLogicalPalette(uint8_t l, uint8_t p, uint8_t r, uint8_t g, uint8_t b) 
 	debug_log("vdu_palette: %d,%d,%d,%d,%d\n\r", l, p, r, g, b);
 	uint8_t index = (col.R >> 6) << 4 | (col.G >> 6) << 2 | (col.B >> 6);
 	// update palette entry
-	palette[l] = index;
+	palette[l & (getVGAColourDepth() - 1)] = index;
 	if (getVGAColourDepth() < 64) {		// If it is a paletted video mode
 		// change underlying output video palette
 		setPaletteItem(l, col);

--- a/video/context.h
+++ b/video/context.h
@@ -14,6 +14,7 @@
 #include "sprites.h"
 
 extern bool isFeatureFlagSet(uint16_t flag);
+extern uint lastFrameCounter;
 
 // Support structures
 
@@ -434,7 +435,7 @@ bool Context::readVariable(uint16_t var, uint16_t * value) {
 				*value = lineThickness;
 			}
 			break;
-		
+
 		// Text cursor absolute position
 		// NB this does not take into account cursor behaviour
 		case 0x18:	// Text cursor, absolute X position (chars)
@@ -447,7 +448,18 @@ bool Context::readVariable(uint16_t var, uint16_t * value) {
 				*value = textCursor.Y / getFont()->height;
 			}
 			break;
-		
+
+		case 0x20:	// Frame counter low
+			if (value) {
+				*value = lastFrameCounter & 0xFFFF;
+			}
+			break;
+		case 0x21:	// Frame counter high
+			if (value) {
+				*value = lastFrameCounter >> 16;
+			}
+			break;
+
 		case 0x55:	// Current screen mode number
 			if (value) {
 				*value = videoMode;
@@ -924,6 +936,15 @@ void Context::setVariable(uint16_t var, uint16_t value) {
 		case 0x19:	// Text cursor, absolute Y (chars)
 			textCursor.Y = value * getFont()->height;
 			ensureCursorInViewport(textViewport);
+			break;
+
+		case 0x20:	// Frame counter low
+			lastFrameCounter = (lastFrameCounter & 0xFFFF0000) | (value & 0xFFFF);
+			_VGAController->frameCounter = lastFrameCounter;
+			break;
+		case 0x21:	// Frame counter high
+			lastFrameCounter = (lastFrameCounter & 0xFFFF) | (value << 16);
+			_VGAController->frameCounter = lastFrameCounter;
 			break;
 
 		case 0x56:	// Legacy modes flag

--- a/video/context.h
+++ b/video/context.h
@@ -378,6 +378,16 @@ bool Context::readVariable(uint16_t var, uint16_t * value) {
 		}
 		return true;
 	}
+	if (var >= FEATUREFLAG_VDU_VAR_CHARMAPPING && var <= FEATUREFLAG_VDU_VAR_CHARMAPPING_END) {
+		auto c = var - FEATUREFLAG_VDU_VAR_CHARMAPPING;
+		if (charToBitmap[c] != 65535) {
+			if (value) {
+				*value = charToBitmap[c];
+			}
+			return true;
+		}
+		return false;
+	}
 	switch (var) {
 		// Mode variables
 		// 0 is "mode flags" - omitting for now
@@ -472,7 +482,7 @@ bool Context::readVariable(uint16_t var, uint16_t * value) {
 				*value = cursorVEnd;
 			}
 			break;
-
+		// Space for cursor timing variables etc
 		case 0x70:	// Active cursor type (read only)
 			if (value) {
 				*value = (activeCursor == &textCursor) ? 0 : 1;
@@ -761,6 +771,10 @@ void Context::setVariable(uint16_t var, uint16_t value) {
 			return;
 		}
 		setLogicalPalette(var - FEATUREFLAG_VDU_VAR_PALETTE, value, 0, 0, 0);
+		return;
+	}
+	if (var >= FEATUREFLAG_VDU_VAR_CHARMAPPING && var <= FEATUREFLAG_VDU_VAR_CHARMAPPING_END) {
+		mapCharToBitmap(var - FEATUREFLAG_VDU_VAR_CHARMAPPING, value);
 		return;
 	}
 	switch (var) {

--- a/video/context.h
+++ b/video/context.h
@@ -223,6 +223,7 @@ class Context {
 		// Viewport management functions
 		void viewportReset();
 		void setActiveViewport(ViewportType type);
+		bool setGraphicsViewport(Point p1, Point p2);
 		bool setGraphicsViewport(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2);
 		bool setGraphicsViewport();
 		bool setTextViewport(uint8_t cx1, uint8_t cy1, uint8_t cx2, uint8_t cy2);
@@ -646,6 +647,64 @@ void Context::setVariable(uint8_t var, uint16_t value) {
 		// - text and graphics windows 0x80-0x87
 		// Currently read-only, as changing them here could break things
 		// since we need to ensure that x,y pairs are correctly ordered
+
+		// - text and graphics windows
+		case 0x80: {	// Graphics window, LH column, pixel coordinates
+			uint16_t y1, x2, y2;
+			readVariable(0x81, &y1);
+			readVariable(0x82, &x2);
+			readVariable(0x83, &y2);
+			setGraphicsViewport(Point(value, y1), Point(x2, y2));
+		}	break;
+		case 0x81: {	// Graphics window, Bottom row, pixel coordinates
+			uint16_t x1, x2, y2;
+			readVariable(0x80, &x1);
+			readVariable(0x82, &x2);
+			readVariable(0x83, &y2);
+			setGraphicsViewport(Point(x1, value), Point(x2, y2));
+		}	break;
+		case 0x82: {	// Graphics window, RH column, pixel coordinates
+			uint16_t x1, y1, y2;
+			readVariable(0x80, &x1);
+			readVariable(0x81, &y1);
+			readVariable(0x83, &y2);
+			setGraphicsViewport(Point(x1, y1), Point(value, y2));
+		}	break;
+		case 0x83: {	// Graphics window, Top row, pixel coordinates
+			uint16_t x1, y1, x2;
+			readVariable(0x80, &x1);
+			readVariable(0x81, &y1);
+			readVariable(0x82, &x2);
+			setGraphicsViewport(Point(x1, y1), Point(x2, value));
+		}	break;
+		case 0x84: {	// Text window, LH column, character coordinates
+			uint16_t y1, x2, y2;
+			readVariable(0x85, &y1);
+			readVariable(0x86, &x2);
+			readVariable(0x87, &y2);
+			setTextViewport(value, y2, x2, y1);
+		}	break;
+		case 0x85: {	// Text window, Bottom row, character coordinates
+			uint16_t x1, y2, x2;
+			readVariable(0x84, &x1);
+			readVariable(0x86, &x2);
+			readVariable(0x87, &y2);
+			setTextViewport(x1, y2, x2, value);
+		}	break;
+		case 0x86: {	// Text window, RH column, character coordinates
+			uint16_t x1, y1, y2;
+			readVariable(0x84, &x1);
+			readVariable(0x85, &y1);
+			readVariable(0x87, &y2);
+			setTextViewport(x1, y2, value, y1);
+		}	break;
+		case 0x87: {	// Text window, Top row, character coordinates
+			uint16_t x1, y1, x2;
+			readVariable(0x84, &x1);
+			readVariable(0x85, &y1);
+			readVariable(0x86, &x2);
+			setTextViewport(x1, value, x2, y1);
+		}	break;
 
 		// Graphics origin (0x88-0x89)
 		case 0x88:	// Graphics origin, X, OS coordinates

--- a/video/context.h
+++ b/video/context.h
@@ -372,14 +372,14 @@ class Context {
 }
 
 bool Context::readVariable(uint16_t var, uint16_t * value) {
-	if (var >= FEATUREFLAG_VDU_VAR_PALETTE && var <= FEATUREFLAG_VDU_VAR_PALETTE_END) {
+	if (var >= VDU_VAR_PALETTE && var <= VDU_VAR_PALETTE_END) {
 		if (value) {
-			*value = palette[(var - FEATUREFLAG_VDU_VAR_PALETTE) & (getVGAColourDepth() - 1)];
+			*value = palette[(var - VDU_VAR_PALETTE) & (getVGAColourDepth() - 1)];
 		}
 		return true;
 	}
-	if (var >= FEATUREFLAG_VDU_VAR_CHARMAPPING && var <= FEATUREFLAG_VDU_VAR_CHARMAPPING_END) {
-		auto c = var - FEATUREFLAG_VDU_VAR_CHARMAPPING;
+	if (var >= VDU_VAR_CHARMAPPING && var <= VDU_VAR_CHARMAPPING_END) {
+		auto c = var - VDU_VAR_CHARMAPPING;
 		if (charToBitmap[c] != 65535) {
 			if (value) {
 				*value = charToBitmap[c];
@@ -766,15 +766,15 @@ bool Context::readVariable(uint16_t var, uint16_t * value) {
 }
 
 void Context::setVariable(uint16_t var, uint16_t value) {
-	if (var >= FEATUREFLAG_VDU_VAR_PALETTE && var <= FEATUREFLAG_VDU_VAR_PALETTE_END) {
+	if (var >= VDU_VAR_PALETTE && var <= VDU_VAR_PALETTE_END) {
 		if (value >= 64) {
 			return;
 		}
-		setLogicalPalette(var - FEATUREFLAG_VDU_VAR_PALETTE, value, 0, 0, 0);
+		setLogicalPalette(var - VDU_VAR_PALETTE, value, 0, 0, 0);
 		return;
 	}
-	if (var >= FEATUREFLAG_VDU_VAR_CHARMAPPING && var <= FEATUREFLAG_VDU_VAR_CHARMAPPING_END) {
-		mapCharToBitmap(var - FEATUREFLAG_VDU_VAR_CHARMAPPING, value);
+	if (var >= VDU_VAR_CHARMAPPING && var <= VDU_VAR_CHARMAPPING_END) {
+		mapCharToBitmap(var - VDU_VAR_CHARMAPPING, value);
 		return;
 	}
 	switch (var) {

--- a/video/context.h
+++ b/video/context.h
@@ -186,8 +186,8 @@ class Context {
 		// Copy constructor
 		Context(const Context &c);
 
-		bool readVariable(uint8_t var, uint16_t * value);
-		void setVariable(uint8_t var, uint16_t value);
+		bool readVariable(uint16_t var, uint16_t * value);
+		void setVariable(uint16_t var, uint16_t value);
 
 		// Cursor management functions
 		void hideCursor();
@@ -371,7 +371,7 @@ class Context {
 	}
 }
 
-bool Context::readVariable(uint8_t var, uint16_t * value) {
+bool Context::readVariable(uint16_t var, uint16_t * value) {
 	switch (var) {
 		// Mode variables
 		// 0 is "mode flags" - omitting for now
@@ -604,17 +604,14 @@ bool Context::readVariable(uint8_t var, uint16_t * value) {
 		// also note that if/when we support variable width fonts, the width here will be zero
 
 		// RISC OS also defines a few other variables beyond these which are not relevant on Agon
-		// there are variables for "width/height of text window in chars" numbered &100 and &101,
-		// but those will not fit into our 8-bit block without renumbering
-		// and their values can be derived from existing viewport variables
 
-		case 0xC1:		// width of text window in chars (renumbered from &100)
+		case 0x100:		// width of text window in chars
 			if (value) {
 				// We will assume that 
 				*value = getNormalisedViewportCharWidth();
 			}
 			break;
-		case 0xC2:		// height of text window in chars (renumbered from &101)
+		case 0x101:		// height of text window in chars
 			if (value) {
 				// Acorn seems to reduce this value by 1 on RISC OS
 				*value = getNormalisedViewportCharHeight() - 1;
@@ -635,7 +632,7 @@ bool Context::readVariable(uint8_t var, uint16_t * value) {
 	return true;
 }
 
-void Context::setVariable(uint8_t var, uint16_t value) {
+void Context::setVariable(uint16_t var, uint16_t value) {
 	switch (var) {
 		// Mode variables (0-13)
 		// All mode variables are read-only

--- a/video/context/cursor.h
+++ b/video/context/cursor.h
@@ -271,7 +271,7 @@ inline void Context::setActiveCursor(CursorType type) {
 	}
 }
 
-inline void Context::setCursorBehaviour(uint8_t setting, uint8_t mask = 0xFF) {
+inline void Context::setCursorBehaviour(uint8_t setting, uint8_t mask = 0) {
 	cursorBehaviour.value = (cursorBehaviour.value & mask) ^ setting;
 }
 

--- a/video/context/graphics.h
+++ b/video/context/graphics.h
@@ -828,6 +828,8 @@ void Context::drawBitmap(uint16_t x, uint16_t y, bool compensateHeight, bool for
 				auto &transformBuffer = transformBufferIter->second;
 				if (!checkTransformBuffer(transformBuffer)) {
 					debug_log("drawBitmap: transform buffer %d is invalid\n\r", bitmapTransform);
+					bitmapTransform = 65535;
+					canvas->drawBitmap(x, yPos, bitmap.get());
 					return;
 				}
 				// NB: if we're drawing via PLOT and are using OS coords, then we _should_ be using bottom left of bitmap as our "origin" for transforms

--- a/video/context/viewport.h
+++ b/video/context/viewport.h
@@ -60,9 +60,7 @@ void Context::setActiveViewport(ViewportType type) {
 }
 
 // Set graphics viewport
-bool Context::setGraphicsViewport(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2) {
-	auto p1 = toScreenCoordinates(x1, y1);
-	auto p2 = toScreenCoordinates(x2, y2);
+bool Context::setGraphicsViewport(Point p1, Point p2) {
 	plottingText = false;
 
 	if (p1.X >= 0 && p2.X < canvasW && p1.Y >= 0 && p2.Y < canvasH && p2.X >= p1.X && p2.Y >= p1.Y) {
@@ -70,6 +68,10 @@ bool Context::setGraphicsViewport(uint16_t x1, uint16_t y1, uint16_t x2, uint16_
 		return true;
 	}
 	return false;
+}
+
+bool Context::setGraphicsViewport(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2) {
+	return setGraphicsViewport(Point(x1, y1), Point(x2, y2));
 }
 
 bool Context::setGraphicsViewport() {

--- a/video/context/viewport.h
+++ b/video/context/viewport.h
@@ -128,11 +128,13 @@ void Context::setOrigin(int x, int y) {
 	up1.X = up1.X - delta.X;
 	up1.Y = up1.Y - delta.Y;
 
+	uOrigin = Point(x, y);
 	origin = newOrigin;
 }
 
 void Context::setOrigin() {
 	origin = p1;
+	uOrigin = up1;
 	up1 = Point(0, 0);
 	debug_log("setOrigin: %d,%d\n\r", origin.X, origin.Y);
 }
@@ -144,6 +146,7 @@ void Context::shiftOrigin() {
 	graphicsViewport = graphicsViewport.translate(originDelta).intersection(defaultViewport);
 
 	origin = p1;
+	uOrigin = up1;
 	up1 = Point(0, 0);
 
 	textCursor = textCursor.add(originDelta);
@@ -159,9 +162,11 @@ void Context::setLogicalCoords(bool b) {
 		if (b) {
 			// point was in screen coordinates, change to logical
 			up1 = Point(up1.X * logicalScaleX, LOGICAL_SCRH - (up1.Y * logicalScaleY));
+			uOrigin = Point(origin.X * logicalScaleX, LOGICAL_SCRH - (origin.Y * logicalScaleY));
 		} else {
 			// point was in logical coordinates, change to screen coordinates
 			up1 = Point(up1.X / logicalScaleX, canvasH - (up1.Y / logicalScaleY));
+			uOrigin = origin;
 		}
 	}
 }

--- a/video/feature_flags.h
+++ b/video/feature_flags.h
@@ -13,7 +13,7 @@ extern VDUStreamProcessor *processor;
 
 void setFeatureFlag(uint16_t flag, uint16_t value) {
 	if (flag >= FEATUREFLAG_VDU_VARIABLES_START && flag <= FEATUREFLAG_VDU_VARIABLES_END) {
-		processor->getContext()->setVariable(flag & 0xFF, value);
+		processor->getContext()->setVariable(flag & FEATUREFLAG_VDU_VARIABLES_MASK, value);
 		return;
 	}
 	switch (flag) {
@@ -54,7 +54,7 @@ void clearFeatureFlag(uint16_t flag) {
 
 bool isFeatureFlagSet(uint16_t flag) {
 	if (flag >= FEATUREFLAG_VDU_VARIABLES_START && flag <= FEATUREFLAG_VDU_VARIABLES_END) {
-		return processor->getContext()->readVariable(flag & 0xFF, nullptr);
+		return processor->getContext()->readVariable(flag & FEATUREFLAG_VDU_VARIABLES_MASK, nullptr);
 	}
 	auto flagIter = featureFlags.find(flag);
 	return flagIter != featureFlags.end();
@@ -63,7 +63,7 @@ bool isFeatureFlagSet(uint16_t flag) {
 uint16_t getFeatureFlag(uint16_t flag) {
 	if (flag >= FEATUREFLAG_VDU_VARIABLES_START && flag <= FEATUREFLAG_VDU_VARIABLES_END) {
 		uint16_t value = 0;
-		processor->getContext()->readVariable(flag & 0xFF, &value);
+		processor->getContext()->readVariable(flag & FEATUREFLAG_VDU_VARIABLES_MASK, &value);
 		return value;
 	}
 	auto flagIter = featureFlags.find(flag);

--- a/video/feature_flags.h
+++ b/video/feature_flags.h
@@ -20,32 +20,38 @@ void setFeatureFlag(uint16_t flag, uint16_t value) {
 		switch (flag) {
 			case FEATUREFLAG_RTC_YEAR:
 				rtc.setTime(rtc.getSecond(), rtc.getMinute(), rtc.getHour(true), rtc.getDay(), rtc.getMonth(), value);
-				break;
+				return;
 			case FEATUREFLAG_RTC_MONTH:
 				rtc.setTime(rtc.getSecond(), rtc.getMinute(), rtc.getHour(true), rtc.getDay(), value, rtc.getYear());
-				break;
+				return;
 			case FEATUREFLAG_RTC_DAY:
 				rtc.setTime(rtc.getSecond(), rtc.getMinute(), rtc.getHour(true), value, rtc.getMonth(), rtc.getYear());
-				break;
+				return;
 			case FEATUREFLAG_RTC_HOUR:
 				rtc.setTime(rtc.getSecond(), rtc.getMinute(), value, rtc.getDay(), rtc.getMonth(), rtc.getYear());
-				break;
+				return;
 			case FEATUREFLAG_RTC_MINUTE:
 				rtc.setTime(rtc.getSecond(), value, rtc.getHour(true), rtc.getDay(), rtc.getMonth(), rtc.getYear());
-				break;
+				return;
 			case FEATUREFLAG_RTC_SECOND:
 				rtc.setTime(value, rtc.getMinute(), rtc.getHour(true), rtc.getDay(), rtc.getMonth(), rtc.getYear());
-				break;
+				return;
+			case FEATUREFLAG_RTC_MILLIS:
+			case FEATUREFLAG_RTC_WEEKDAY:
+			case FEATUREFLAG_RTC_YEARDAY:
+			case FEATUREFLAG_FREEPSRAM_LOW:
+			case FEATUREFLAG_FREEPSRAM_HIGH:
+			case FEATUREFLAG_BUFFERS_USED:
+				return;
 
 			case FEATUREFLAG_KEYBOARD_LAYOUT:
 				setKeyboardLayout(value);
-				break;
+				return;
 			
 			case FEATUREFLAG_KEYBOARD_CTRL_KEYS:
 				controlKeys = value != 0;
-				break;
+				return;
 		}
-		return;
 	}
 	switch (flag) {
 		case FEATUREFLAG_FULL_DUPLEX:
@@ -105,7 +111,6 @@ bool isFeatureFlagSet(uint16_t flag) {
 			case FEATUREFLAG_KEYBOARD_CTRL_KEYS:
 				return true;
 		}
-		return false;
 	}
 	auto flagIter = featureFlags.find(flag);
 	return flagIter != featureFlags.end();

--- a/video/feature_flags.h
+++ b/video/feature_flags.h
@@ -12,6 +12,10 @@ std::unordered_map<uint16_t, uint16_t> featureFlags;	// Feature/Test flags
 extern VDUStreamProcessor *processor;
 
 void setFeatureFlag(uint16_t flag, uint16_t value) {
+	if (flag >= FEATUREFLAG_VDU_VARIABLES_START && flag <= FEATUREFLAG_VDU_VARIABLES_END) {
+		processor->getContext()->setVariable(flag & 0xFF, value);
+		return;
+	}
 	switch (flag) {
 		case FEATUREFLAG_FULL_DUPLEX:
 			setVDPProtocolDuplex(value != 0);

--- a/video/feature_flags.h
+++ b/video/feature_flags.h
@@ -48,16 +48,23 @@ void clearFeatureFlag(uint16_t flag) {
 	}
 }
 
-inline bool isFeatureFlagSet(uint16_t flag) {
+bool isFeatureFlagSet(uint16_t flag) {
+	if (flag >= FEATUREFLAG_VDU_VARIABLES_START && flag <= FEATUREFLAG_VDU_VARIABLES_END) {
+		return processor->getContext()->readVariable(flag & 0xFF, nullptr);
+	}
 	auto flagIter = featureFlags.find(flag);
 	return flagIter != featureFlags.end();
 }
 
-inline uint16_t getFeatureFlag(uint16_t flag) {
+uint16_t getFeatureFlag(uint16_t flag) {
+	if (flag >= FEATUREFLAG_VDU_VARIABLES_START && flag <= FEATUREFLAG_VDU_VARIABLES_END) {
+		uint16_t value = 0;
+		processor->getContext()->readVariable(flag & 0xFF, &value);
+		return value;
+	}
 	auto flagIter = featureFlags.find(flag);
 	if (flagIter != featureFlags.end()) {
 		return featureFlags[flag];
-		// return flagIter->second;
 	}
 	return 0;
 }

--- a/video/feature_flags.h
+++ b/video/feature_flags.h
@@ -51,6 +51,11 @@ void setFeatureFlag(uint16_t flag, uint16_t value) {
 			case FEATUREFLAG_KEYBOARD_CTRL_KEYS:
 				controlKeys = value != 0;
 				return;
+			
+			case FEATUREFLAG_CONTEXT_ID:
+				processor->selectContext(value);
+				processor->sendModeInformation();
+				return;
 		}
 	}
 	switch (flag) {
@@ -109,6 +114,7 @@ bool isFeatureFlagSet(uint16_t flag) {
 			case FEATUREFLAG_BUFFERS_USED:
 			case FEATUREFLAG_KEYBOARD_LAYOUT:
 			case FEATUREFLAG_KEYBOARD_CTRL_KEYS:
+			case FEATUREFLAG_CONTEXT_ID:
 				return true;
 		}
 	}
@@ -159,6 +165,9 @@ uint16_t getFeatureFlag(uint16_t flag) {
 
 			case FEATUREFLAG_KEYBOARD_CTRL_KEYS:
 				return controlKeys ? 1 : 0;
+			
+			case FEATUREFLAG_CONTEXT_ID:
+				return processor->contextId;
 		}
 	}
 	return 0;

--- a/video/vdu.h
+++ b/video/vdu.h
@@ -306,7 +306,7 @@ void VDUStreamProcessor::vdu_graphicsViewport() {
 	auto x2 = readWord_t();			// Right
 	auto y1 = readWord_t();			// Top
 
-	if (context->setGraphicsViewport(x1, y1, x2, y2)) {
+	if (context->setGraphicsViewport(context->toScreenCoordinates(x1, y1), context->toScreenCoordinates(x2,y2))) {
 		debug_log("vdu_graphicsViewport: OK %d,%d,%d,%d\n\r", x1, y1, x2, y2);
 	} else {
 		debug_log("vdu_graphicsViewport: Invalid Viewport %d,%d,%d,%d\n\r", x1, y1, x2, y2);

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -32,7 +32,6 @@ class VDUStreamProcessor {
 		// Graphics context storage and management
 		std::shared_ptr<Context> context;		// Current active context
 		ContextVectorPtr contextStack;			// Current active context stack
-		uint8_t contextId = 0;					// Current active context ID
 
 		bool commandsEnabled = true;
 		bool echoEnabled = false;
@@ -99,7 +98,6 @@ class VDUStreamProcessor {
 		void vdu_sys_font();
 
 		void vdu_sys_context();
-		void selectContext(uint8_t contextId);
 		bool resetContext(uint8_t flags);
 		void saveContext();
 		void restoreContext();
@@ -237,6 +235,7 @@ class VDUStreamProcessor {
 
 	public:
 		uint16_t id = 65535;
+		uint8_t contextId = 0;					// Current active context ID
 
 		VDUStreamProcessor(Stream *input) :
 			inputStream(std::shared_ptr<Stream>(input)), outputStream(inputStream), originalOutputStream(inputStream) {
@@ -310,6 +309,7 @@ class VDUStreamProcessor {
 		bool contextExists(uint8_t id) {
 			return contextStacks.find(id) != contextStacks.end();
 		}
+		void selectContext(uint8_t contextId);
 
 		void vdu_mode(uint8_t mode);
 

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include <fabgl.h>
-#include <ESP32Time.h>
 
 #include "agon.h"
 #include "agon_ps2.h"
@@ -25,7 +24,6 @@ extern void setConsoleMode(bool mode);			// Set console mode
 extern bool controlKeys;	
 
 bool			initialised = false;			// Is the system initialised yet?
-ESP32Time		rtc(0);							// The RTC
 
 // Buffer for serialised time
 //

--- a/video/video.ino
+++ b/video/video.ino
@@ -48,6 +48,7 @@
 #include <HardwareSerial.h>
 #include <WiFi.h>
 #include <fabgl.h>
+#include <ESP32Time.h>
 
 // Serial Debug Mode: 1 = enable
 // Always enabled on the emulator, to support --verbose mode
@@ -76,6 +77,7 @@ bool			consoleMode = false;			// Serial console mode (0 = off, 1 = console enabl
 bool			printerOn = false;				// Output "printer" to debug serial link
 bool			controlKeys = true;				// Control keys enabled
 uint			lastFrameCounter = 0;			// Last frame counter
+ESP32Time		rtc(0);							// The RTC
 
 #include "version.h"							// Version information
 #include "agon_ps2.h"							// Keyboard support


### PR DESCRIPTION
Context state as “VDU Variables” within the feature flag space

These variables occupy the range 0x1000-0x1FFF

Where appropriate, variables can be written to, adjusting the underlying graphics system state.

Some additional variables related to system state, and thus not strictly "vdu variables" are also added inside the range 0-0xFFF

The first set of variables implemented closely matches VDU Variables (including Mode Variables) on RISC OS systems.  Additional variables that are Agon-specific, or exposing the graphics system state that RISC OS does not provide access to via their VDU Variables mechanism (but may be available elsewhere) have also been added.

(Builds on #285)