### PR TITLE
temporarily hide/show cursor on CLS

### DIFF
--- a/video/context/graphics.h
+++ b/video/context/graphics.h
@@ -877,6 +877,7 @@ void Context::setAffineTransform(uint8_t flags, uint16_t bufferId) {
 // Clear the screen
 //
 void Context::cls() {
+	hideCursor();
 	if (hasActiveSprites()) {
 		activateSprites(0);
 	}
@@ -890,6 +891,7 @@ void Context::cls() {
 	}
 	cursorHome();
 	setPagedMode(pagedMode);
+	showCursor();
 }
 
 // Clear the graphics area


### PR DESCRIPTION
this fixes an issue whereby performing a CLS can leave behind a “cursor block”, fixing #284