### PR TITLE
ensure mode change selects default context

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -230,6 +230,7 @@
 #define CONTEXT_SAVE_AND_SELECT			5		// Save and get a copy of topmost context from numbered stack
 #define CONTEXT_RESTORE_ALL				6		// Clear stack and restore to first context in stack
 #define CONTEXT_CLEAR_STACK				7		// Clear stack, keeping current context
+#define CONTEXT_DEBUG					0x80	// Get debug info about a context
 
 #define CONTEXT_RESET_GPAINT			0x01	// graphics painting options
 #define CONTEXT_RESET_GPOS				0x02	// graphics positioning incl graphics viewport

--- a/video/vdu_context.h
+++ b/video/vdu_context.h
@@ -61,6 +61,14 @@ void VDUStreamProcessor::vdu_sys_context() {
 		case CONTEXT_CLEAR_STACK: {	// VDU 23, 0, &C8, 7
 			clearContextStack();
 		} break;
+		case CONTEXT_DEBUG: {	// VDU 23, 0, &C8, &80
+			debug_log("vdu_sys_context: selected context stack ID %d\n\r", contextId);
+			debug_log("vdu_sys_context: current stack size %d\n\r", contextStack->size());
+			debug_log("vdu_sys_context: available contexts %d\n\r", contextStacks.size());
+			for (auto it = contextStacks.begin(); it != contextStacks.end(); ++it) {
+				debug_log("vdu_sys_context: context id %d, stack size %d\n\r", it->first, it->second->size());
+			}
+		} break;
 	}
 }
 
@@ -180,8 +188,10 @@ void VDUStreamProcessor::clearContextStack() {
 //
 void VDUStreamProcessor::resetAllContexts() {
 	debug_log("resetAllContexts: resetting all contexts\n\r");
+	selectContext(0);
 	clearContextStack();
 	contextStacks.clear();
+	contextStacks[0] = contextStack;
 	// perform a "mode" style reset
 	resetContext(0);
 }


### PR DESCRIPTION
adds a call to select context 0 into `resetAllContexts`, ensuring that the default is set, and also ensure that the stack is saved

also add a context debug call to see info about available contexts