### PR TITLE
replace current sprite frame command

### DIFF
--- a/video/vdu_sprites.h
+++ b/video/vdu_sprites.h
@@ -177,6 +177,12 @@ void VDUStreamProcessor::vdu_sys_sprites() {
 			debug_log("vdu_sys_sprites: sprite %d is software\n\r", getCurrentSprite());
 		}	break;
 
+		case 21: {	// Replace current sprite frame with bitmap
+			auto b = readByte_t(); if (b == -1) return;
+			replaceSpriteFrame(b + BUFFERED_BITMAP_BASEID);
+			debug_log("vdu_sys_sprites: sprite %d - replace frame %d\n\r", getCurrentSprite(), b);
+		}	break;
+
 		// Extended bitmap commands
 		case 0x20: {	// Select bitmap, 16-bit buffer ID
 			auto b = readWord_t(); if (b == -1) return;
@@ -201,6 +207,12 @@ void VDUStreamProcessor::vdu_sys_sprites() {
 			auto bufferId = readWord_t(); if (bufferId == -1) return;
 			addSpriteFrame(bufferId);
 			debug_log("vdu_sys_sprites: sprite %d - bitmap %d added as frame %d\n\r", getCurrentSprite(), bufferId, getSprite()->framesCount-1);
+		}	break;
+
+		case 0x35: {	// Replace current sprite frame with bitmap (long ID)
+			auto bufferId = readWord_t(); if (bufferId == -1) return;
+			replaceSpriteFrame(bufferId);
+			debug_log("vdu_sys_sprites: sprite %d - replace frame with bitmap %d\n\r", getCurrentSprite(), bufferId);
 		}	break;
 
 		case 0x40: {	// Setup mouse cursor from current bitmap


### PR DESCRIPTION
adds a pair of new commands to the sprite API that will let you replace the currently selected frame of a sprite with a different bitmap