### PR TITLE
Add new 640x512 and 640x256 screen modes.

### DIFF
--- a/video/agon_screen.h
+++ b/video/agon_screen.h
@@ -101,7 +101,7 @@ inline uint8_t getVGAColourDepth() {
 // Parameters:
 // - l: The logical colour to change
 // - c: The new colour
-// 
+//
 void setPaletteItem(uint8_t l, RGB888 c) {
 	auto depth = getVGAColourDepth();
 	if (l < depth && depth <= 16) {
@@ -360,6 +360,27 @@ int8_t changeMode(uint8_t mode) {
 		case 23:
 			errVal = changeResolution(2, VGA_512x384_60Hz);
 			break;
+		case 24:
+			errVal = changeResolution(16, VGA_640x512_60Hz);
+			break;
+		case 25:
+			errVal = changeResolution(4, VGA_640x512_60Hz);
+			break;
+		case 26:
+			errVal = changeResolution(2, VGA_640x512_60Hz);
+			break;
+		case 27:
+			errVal = changeResolution(64, VGA_640x256_60Hz);
+			break;
+		case 28:
+			errVal = changeResolution(16, VGA_640x256_60Hz);
+			break;
+		case 29:
+			errVal = changeResolution(4, VGA_640x256_60Hz);
+			break;
+		case 30:
+			errVal = changeResolution(2, VGA_640x256_60Hz);
+			break;
 		case 129:
 			errVal = changeResolution(4, VGA_640x480_60Hz, true);
 			break;
@@ -414,6 +435,23 @@ int8_t changeMode(uint8_t mode) {
 		case 151:
 			errVal = changeResolution(2, VGA_512x384_60Hz, true);
 			break;
+		case 153:
+			errVal = changeResolution(4, VGA_640x512_60Hz, true);
+			break;
+		case 154:
+			errVal = changeResolution(2, VGA_640x512_60Hz, true);
+			break;
+		case 156:
+			errVal = changeResolution(16, VGA_640x256_60Hz, true);
+			break;
+		case 157:
+			errVal = changeResolution(4, VGA_640x256_60Hz, true);
+			break;
+		case 158:
+			errVal = changeResolution(2, VGA_640x256_60Hz, true);
+			break;
+
+
 	}
 
 	debug_log("changeMode: canvas(%d,%d), scale(%f,%f), mode %d, videoMode %d\n\r", canvasW, canvasH, logicalScaleX, logicalScaleY, mode, videoMode);

--- a/video/agon_screen.h
+++ b/video/agon_screen.h
@@ -361,25 +361,25 @@ int8_t changeMode(uint8_t mode) {
 			errVal = changeResolution(2, VGA_512x384_60Hz);
 			break;
 		case 24:
-			errVal = changeResolution(16, VGA_640x512_60Hz);
+			errVal = changeResolution(16, QSVGA_640x512_60Hz);
 			break;
 		case 25:
-			errVal = changeResolution(4, VGA_640x512_60Hz);
+			errVal = changeResolution(4, QSVGA_640x512_60Hz);
 			break;
 		case 26:
-			errVal = changeResolution(2, VGA_640x512_60Hz);
+			errVal = changeResolution(2, QSVGA_640x512_60Hz);
 			break;
 		case 27:
-			errVal = changeResolution(64, VGA_640x256_60Hz);
+			errVal = changeResolution(64, QSVGA_640x256_60Hz);
 			break;
 		case 28:
-			errVal = changeResolution(16, VGA_640x256_60Hz);
+			errVal = changeResolution(16, QSVGA_640x256_60Hz);
 			break;
 		case 29:
-			errVal = changeResolution(4, VGA_640x256_60Hz);
+			errVal = changeResolution(4, QSVGA_640x256_60Hz);
 			break;
 		case 30:
-			errVal = changeResolution(2, VGA_640x256_60Hz);
+			errVal = changeResolution(2, QSVGA_640x256_60Hz);
 			break;
 		case 129:
 			errVal = changeResolution(4, VGA_640x480_60Hz, true);
@@ -436,19 +436,19 @@ int8_t changeMode(uint8_t mode) {
 			errVal = changeResolution(2, VGA_512x384_60Hz, true);
 			break;
 		case 153:
-			errVal = changeResolution(4, VGA_640x512_60Hz, true);
+			errVal = changeResolution(4, QSVGA_640x512_60Hz, true);
 			break;
 		case 154:
-			errVal = changeResolution(2, VGA_640x512_60Hz, true);
+			errVal = changeResolution(2, QSVGA_640x512_60Hz, true);
 			break;
 		case 156:
-			errVal = changeResolution(16, VGA_640x256_60Hz, true);
+			errVal = changeResolution(16, QSVGA_640x256_60Hz, true);
 			break;
 		case 157:
-			errVal = changeResolution(4, VGA_640x256_60Hz, true);
+			errVal = changeResolution(4, QSVGA_640x256_60Hz, true);
 			break;
 		case 158:
-			errVal = changeResolution(2, VGA_640x256_60Hz, true);
+			errVal = changeResolution(2, QSVGA_640x256_60Hz, true);
 			break;
 
 


### PR DESCRIPTION
These modes are supported by vdp-gl and allow users that have 1280x1024 monitors to display in its native 5:4 ratio, instead of a stretched 4:3 when using 640x480.