### PR TITLE
fix firmware update, and hardware sprites

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@ board_build.f_cpu = 240000000L
 board_build.f_flash = 80000000L
 framework = arduino
 lib_deps =
-    https://github.com/AgonConsole8/vdp-gl.git#hard-copper
+    https://github.com/AgonConsole8/vdp-gl.git#firm-sprites
     fbiego/ESP32Time@^2.0.0
     robtillaart/CRC@^1.0.3
 build_unflags = -Os

--- a/video/updater.h
+++ b/video/updater.h
@@ -64,6 +64,7 @@ void VDUStreamProcessor::receiveFirmware() {
 	uint32_t remaining_bytes = update_size;
 	uint8_t code = 0;
 	const size_t buffer_size = 1024;
+	uint8_t buffer[buffer_size];
 
 	while(remaining_bytes > 0) {
 
@@ -73,8 +74,6 @@ void VDUStreamProcessor::receiveFirmware() {
 		{
 			bytes_to_read = remaining_bytes;
 		}
-
-		uint8_t buffer[buffer_size];
 
 		bytes_remain = readIntoBuffer(buffer, bytes_to_read);
 		if(bytes_remain) {
@@ -108,7 +107,7 @@ void VDUStreamProcessor::receiveFirmware() {
 		printFmt("Checksum not received!\n\r");
 		return;
 	}
-	printFmt("checksum_complement: 0x%x\n\r", checksum_complement);
+	printFmt("checksum_complement: 0x%02x\n\r", checksum_complement);
 	if(uint8_t(code + (uint8_t)checksum_complement)) {
 		printFmt("checksum error!\n\r");
 		return;
@@ -117,7 +116,7 @@ void VDUStreamProcessor::receiveFirmware() {
 
 	err = esp_ota_set_boot_partition(update_partition);
 	if (err != ESP_OK) {
-		printFmt("esp_ota_set_boot_partition failed! err=0x%x\n\r", err);
+		printFmt("esp_ota_set_boot_partition failed! err=0x%02x\n\r", err);
 		return;
 	}
 


### PR DESCRIPTION
updates vdp-gl to the new `firm-sprites` tag which includes fixes for a crash triggered when the firmware update process is happening, and a crash that can occur when using hardware sprites with RGBA2222 format bitmaps

also includes some very minor tweaks to the firmware updater code