### PR TITLE
use an event queue for keyboard and mouse packets

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -22,11 +22,16 @@ lib_deps =
     https://github.com/AgonPlatform/vdp-gl.git#firm-sprites
     fbiego/ESP32Time@^2.0.0
     robtillaart/CRC@^1.0.3
-build_unflags = -Os
+build_unflags =
+    -Os
+    -std=c++11
+    -std=gnu++11
 build_flags =
     -O2
     -DBOARD_HAS_PSRAM
     -mfix-esp32-psram-cache-issue
+    -std=c++17
+    -std=gnu++17
 ; build_type = debug
 monitor_filters = esp32_exception_decoder
 monitor_speed = 115200

--- a/video/types.h
+++ b/video/types.h
@@ -323,3 +323,13 @@ int32_t textToWord(const char * text) {
 	debug_log("converted text %s is %u\n\r", text,val);
 	return (val < 65536 ? val : -1);
 };
+
+enum class KeyboardEvent {};
+enum class MouseEvent {};
+
+template<class... Ts>
+struct overloaded : Ts... {
+	using Ts::operator()...;
+};
+// Deduction guide for C++17
+template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;

--- a/video/utils/thread_safe_variant_deque.h
+++ b/video/utils/thread_safe_variant_deque.h
@@ -1,0 +1,112 @@
+#ifndef THREAD_SAFE_VARIANT_DEQUE_H
+#define THREAD_SAFE_VARIANT_DEQUE_H
+
+#include <deque>
+#include <mutex>
+#include <variant>
+#include <algorithm>
+
+template<typename... Ts>
+class ThreadSafeVariantDeque {
+public:
+	using value_type = std::variant<Ts...>;
+
+private:
+	std::deque<value_type> deque_;
+	mutable std::mutex mutex_;
+
+	template<typename U>
+	bool containsType_unlocked() const {
+		static_assert((std::disjunction_v<std::is_same<U, Ts>...>),
+					"Type U must be one of the alternatives in std::variant<Ts...>");
+		return std::any_of(deque_.begin(), deque_.end(), [](const value_type& v) {
+			return std::holds_alternative<U>(v);
+		});
+	}
+
+public:
+	// Push to back
+	template<typename T>
+	void push(T&& item) {
+		std::lock_guard<std::mutex> lock(mutex_);
+		deque_.emplace_back(std::forward<T>(item));
+	}
+
+	// Push to back if an item of the given type not already present
+	template<typename T>
+	bool pushUnique(T&& item) {
+		std::lock_guard<std::mutex> lock(mutex_);
+		if (!containsType_unlocked<T>()) {
+			deque_.emplace_back(std::forward<T>(item));
+			return true;
+		}
+		return false;
+	}
+
+	// Push to back if a value of the given type not already present
+	// template<typename T>
+	// bool pushUniqueValue(T&& item) {
+	// 	std::lock_guard<std::mutex> lock(mutex_);
+		
+	// 	// Check if this specific VALUE exists
+	// 	bool valueExists = std::any_of(deque_.begin(), deque_.end(), [&item](const value_type& v) {
+	// 		if (std::holds_alternative<T>(v)) {
+	// 			return std::get<T>(v) == item;
+	// 		}
+	// 		return false;
+	// 	});
+		
+	// 	if (!valueExists) {
+	// 		deque_.emplace_back(std::forward<T>(item));
+	// 		return true;
+	// 	}
+	// 	return false;
+	// }
+
+	// Get the next item without removing it
+	bool peek(value_type& item) const {
+		std::lock_guard<std::mutex> lock(mutex_);
+		if (deque_.empty()) {
+			return false;
+		}
+		item = deque_.front();	// Copy the front item
+		return true;
+	}
+
+	// Pop from front
+	bool pop(value_type& item) {
+		std::lock_guard<std::mutex> lock(mutex_);
+		if (deque_.empty()) {
+			return false;
+		}
+		item = std::move(deque_.front());
+		deque_.pop_front();
+		return true;
+	}
+
+	// Pop with no return values
+	void pop() {
+		std::lock_guard<std::mutex> lock(mutex_);
+		if (!deque_.empty()) {
+			deque_.pop_front();
+		}
+	}
+
+	bool empty() const {
+		std::lock_guard<std::mutex> lock(mutex_);
+		return deque_.empty();
+	}
+
+	size_t size() const {
+		std::lock_guard<std::mutex> lock(mutex_);
+		return deque_.size();
+	}
+
+	template<typename U>
+	bool containsType() const {
+		std::lock_guard<std::mutex> lock(mutex_);
+		return containsType_unlocked<U>();
+	}
+};
+
+#endif // THREAD_SAFE_VARIANT_DEQUE_H


### PR DESCRIPTION
refactors how the VDUStreamProcessor handles keyboard and mouse events

introduces an `eventQueue`, which uses a custom thread-safe queue.  this queue is FIFO, and supports a `pushUnique` method to only push an entry it another of the same class is not already present.  this style of pushing is used for the keyboard and mouse events, in place of the previous boolean flags

this queue system will also allow us to add audio events to the queue handler at a later date, allowing this queue to be used for audio event handling including event callbacks in a manner that will be thread-safe

this uses C++17 features, so the build config has now been updated to use that