### PR TITLE
add support for suppressing next VDP packet

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -438,6 +438,7 @@
 
 #define VDPVAR_FULL_DUPLEX			0x0101	// Full duplex UART comms flag
 #define TESTFLAG_VDPP_BUFFERSIZE	0x0102	// Buffer size on MOS for VDP protocol packets
+#define VDPVAR_VDPP_SUPPRESSNEXT	0x0103	// Suppress sending the next VDP protocol packet
 #define TESTFLAG_ECHO				0x0110	// Echo back received data, for redirect/spool
 // #define TESTFLAG_ECHO_SETTINGS	0x0111	// Settings for what will be echo'd
 #define VDPVAR_SYSTEM_BEGIN			0x0200	// General system settings start at 0x0200
@@ -498,6 +499,7 @@
 #define VDPVAR_KEYEVENT_SCANCODE2	0x026D	// Key scancode bytes 3 and 4
 #define VDPVAR_KEYEVENT_SCANCODE3	0x026E	// Key scancode bytes 5 and 6
 #define VDPVAR_KEYEVENT_SCANCODE4	0x026F	// Key scancode bytes 7 and 8
+#define VDPVAR_GENERALPOLL_BYTE		0x0280	// Last "general poll" byte received
 #define TESTFLAG_TILE_ENGINE		0x0300	// Tile engine flag (layers commands)
 #define VDPVAR_COPPER				0x0310	// Copper feature flag
 #define VDPVAR_AUTO_HW_SPRITES		0x0400	// Auto hardware sprites flag

--- a/video/vdp_variables.h
+++ b/video/vdp_variables.h
@@ -112,6 +112,7 @@ void setVDPVariable(uint16_t flag, uint16_t value) {
 					disableMouse();
 				}
 				return;
+			// Mouse variables - several of these get saved into variables, so don't return
 			case VDPVAR_MOUSE_XPOS: {	// Mouse cursor X position (pixel coords)
 				uint16_t mouseY = getVDPVariable(VDPVAR_MOUSE_YPOS);
 				auto status = setMousePos(value, mouseY);

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -233,7 +233,9 @@ void VDUStreamProcessor::vdu_sys_audio() {
 // Send an audio acknowledgement
 //
 void VDUStreamProcessor::sendAudioStatus(uint8_t channel, uint8_t status) {
+	// TODO: store channel and status in VDP variables to allow them to be changed
 	bufferCallCallbacks(CALLBACK_SENDING_VDPP | PACKET_AUDIO);
+	// and build the packet using those variables
 	uint8_t packet[] = {
 		channel,
 		status,

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -22,6 +22,8 @@ using EventQueue = ThreadSafeVariantDeque<KeyboardEvent, MouseEvent>;
 EventQueue eventQueue;
 
 extern uint16_t getVDPVariable(uint16_t flag);
+extern void setVDPVariable(uint16_t flag, uint16_t value);
+extern void clearVDPVariable(uint16_t flag);
 
 class VDUStreamProcessor {
 	private:
@@ -505,6 +507,12 @@ bool VDUStreamProcessor::readFloatArguments(float *values, int count, bool useBu
 // Send a packet of data to the MOS
 //
 void VDUStreamProcessor::send_packet(uint8_t code, uint16_t len, uint8_t data[]) {
+	if (isVDPVariableSet(VDPVAR_VDPP_SUPPRESSNEXT)) {
+		// Skip sending this packet
+		clearVDPVariable(VDPVAR_VDPP_SUPPRESSNEXT);
+		debug_log("send_packet: Skipping packet 0x%02X\n\r", code);
+		return;
+	}
 	writeByte(code + 0x80);
 	writeByte(len);
 	for (int i = 0; i < len; i++) {

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -381,9 +381,10 @@ void VDUStreamProcessor::sendGeneralPoll() {
 		debug_log("sendGeneralPoll: Timeout\n\r");
 		return;
 	}
+	setVDPVariable(VDPVAR_GENERALPOLL_BYTE, b);
 	bufferCallCallbacks(CALLBACK_SENDING_VDPP | PACKET_GP);
 	uint8_t packet[] = {
-		(uint8_t) (b & 0xFF),
+		(uint8_t) (getVDPVariable(VDPVAR_GENERALPOLL_BYTE) & 0xFF),
 	};
 	send_packet(PACKET_GP, sizeof packet, packet);
 	initialised = true;
@@ -405,6 +406,8 @@ void VDUStreamProcessor::sendCursorPosition() {
 	uint8_t x, y;
 
 	bufferCallCallbacks(CALLBACK_SENDING_VDPP | PACKET_CURSOR);
+	// NB whilst we're not fetching variables for x and y, changing the cursor position
+	// via VDP variables in a callback would still affect the output of this function
 	context->getCursorTextPosition(&x, &y);
 	
 	uint8_t packet[] = { x, y };


### PR DESCRIPTION
adds VDP variable `0x103` which when set will cause the next VDP protocol packet to be suppressed

this can be used in a VDP protocol “about to send packet” callback to prevent that packet from being sent

this is needed since the buffered command “set output stream to -1” won’t work inside an event callback, as the output stream will be restored when the buffer call completes

also adds VDP variable `0x280` for the “general poll byte”.  an “about to send generall poll packet” event can thus be intercepted and the poll byte being sent back to MOS adjusted to a different value