### PR TITLE
fix logical error in transform matrix code

### DIFF
--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -1730,7 +1730,7 @@ void VDUStreamProcessor::bufferAffineTransform(uint16_t bufferId, uint8_t comman
 				return;
 			}
 			for (int i = 0; i < dimensions; i++) {
-				transform[i * size.columns + (i + 1)] = shearXY[i];
+				transform[i * size.columns + ((dimensions - 1) - i)] = shearXY[i];
 			}
 		}	break;
 		case AFFINE_SKEW:
@@ -1743,7 +1743,7 @@ void VDUStreamProcessor::bufferAffineTransform(uint16_t bufferId, uint8_t comman
 				return;
 			}
 			for (int i = 0; i < dimensions; i++) {
-				transform[i * size.columns + (i + 1)] = tanf(conversion * skewXY[i]);
+				transform[i * size.columns + ((dimensions - 1) - i)] = tanf(conversion * skewXY[i]);
 			}
 		}	break;
 		case AFFINE_TRANSFORM: {


### PR DESCRIPTION
the logic has been fixed for how both the shear and skew affine transforms handle creating their transform matrix

there had been a logical error which meant for a 2d transform the read Y value (or value derived from it) would be placed at the wrong index in the transform matrix.  for 3d transforms, the Z value would also be incorrectly handled

thanks to Richard Turnnidge for pointing out the bug!