### PR TITLE
fix audio status return for underlying samplerate

### DIFF
--- a/video/agon_audio.h
+++ b/video/agon_audio.h
@@ -186,7 +186,7 @@ uint8_t setSampleRate(uint8_t channel, uint16_t sampleRate) {
 	if (channel == 255) {
 		// set underlying sample rate
 		setSampleRate(sampleRate);
-		return 0;
+		return 1;
 	}
 	if (channelEnabled(channel)) {
 		return audioChannels[channel]->setSampleRate(sampleRate);


### PR DESCRIPTION
this command was eroneously returning a `0` status when processed, which tends to mean a command could not be processed…

now returns a `1`